### PR TITLE
feat: add auth, bind, dnsmasq, and interfaces_assign resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
-	github.com/browningluke/opnsense-go v0.14.0
+	github.com/browningluke/opnsense-go v0.15.0
 	github.com/hashicorp/terraform-plugin-docs v0.23.0
 	github.com/hashicorp/terraform-plugin-framework v1.16.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.9.1 h1:X8jg9rRZmJd4yRy7ZeNDRnM+T3ZfHv15JiBJ/avrEXE=
 github.com/bmatcuk/doublestar/v4 v4.9.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
-github.com/browningluke/opnsense-go v0.14.0 h1:1TCX6V4aZ7Yv0oftM3HQc6a7S0OjoJEzEo7fTYMjffQ=
-github.com/browningluke/opnsense-go v0.14.0/go.mod h1:zh2ofl18Q4soldkfczxgbHddNU7NoCDyIuutVN6sOrM=
+github.com/browningluke/opnsense-go v0.15.0 h1:TS9KY+/kiutRAHLsA3LFb8ey3HCAGF00WgN9hZwKdmo=
+github.com/browningluke/opnsense-go v0.15.0/go.mod h1:zh2ofl18Q4soldkfczxgbHddNU7NoCDyIuutVN6sOrM=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,7 +6,10 @@ import (
 	"strconv"
 
 	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/terraform-provider-opnsense/internal/service/auth"
+	"github.com/browningluke/terraform-provider-opnsense/internal/service/bind"
 	"github.com/browningluke/terraform-provider-opnsense/internal/service/diagnostics"
+	"github.com/browningluke/terraform-provider-opnsense/internal/service/dnsmasq"
 	"github.com/browningluke/terraform-provider-opnsense/internal/service/firewall"
 	"github.com/browningluke/terraform-provider-opnsense/internal/service/interfaces"
 	"github.com/browningluke/terraform-provider-opnsense/internal/service/ipsec"
@@ -283,7 +286,10 @@ func (p *opnsenseProvider) Configure(ctx context.Context, req provider.Configure
 
 func (p *opnsenseProvider) Resources(ctx context.Context) []func() resource.Resource {
 	controllers := [][]func() resource.Resource{
+		auth.Resources(ctx),
+		bind.Resources(ctx),
 		diagnostics.Resources(ctx),
+		dnsmasq.Resources(ctx),
 		firewall.Resources(ctx),
 		interfaces.Resources(ctx),
 		ipsec.Resources(ctx),
@@ -303,7 +309,10 @@ func (p *opnsenseProvider) Resources(ctx context.Context) []func() resource.Reso
 
 func (p *opnsenseProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	controllers := [][]func() datasource.DataSource{
+		auth.DataSources(ctx),
+		bind.DataSources(ctx),
 		diagnostics.DataSources(ctx),
+		dnsmasq.DataSources(ctx),
 		firewall.DataSources(ctx),
 		interfaces.DataSources(ctx),
 		ipsec.DataSources(ctx),

--- a/internal/service/auth/exports.go
+++ b/internal/service/auth/exports.go
@@ -1,23 +1,22 @@
-package interfaces
+package auth
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 func Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		newAssignResource,
-		newVipResource,
-		newVlanResource,
+		newUserResource,
+		newGroupResource,
 	}
 }
 
 func DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		newAssignDataSource,
-		newVipDataSource,
-		newVlanDataSource,
+		newUserDataSource,
+		newGroupDataSource,
 	}
 }

--- a/internal/service/auth/group_data_source.go
+++ b/internal/service/auth/group_data_source.go
@@ -1,0 +1,76 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ datasource.DataSource = &groupDataSource{}
+var _ datasource.DataSourceWithConfigure = &groupDataSource{}
+
+func newGroupDataSource() datasource.DataSource {
+	return &groupDataSource{}
+}
+
+// groupDataSource defines the data source implementation.
+type groupDataSource struct {
+	client opnsense.Client
+}
+
+func (d *groupDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_auth_group"
+}
+
+func (d *groupDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = groupDataSourceSchema()
+}
+
+func (d *groupDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = opnsense.NewClient(apiClient)
+}
+
+func (d *groupDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data *groupResourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := d.client.Auth().GetGroup(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read auth group, got error: %s", err))
+		return
+	}
+
+	resourceModel, err := convertGroupStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read auth group, got error: %s", err))
+		return
+	}
+
+	resourceModel.Id = data.Id
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}

--- a/internal/service/auth/group_resource.go
+++ b/internal/service/auth/group_resource.go
@@ -1,0 +1,171 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &groupResource{}
+var _ resource.ResourceWithConfigure = &groupResource{}
+var _ resource.ResourceWithImportState = &groupResource{}
+
+func newGroupResource() resource.Resource {
+	return &groupResource{}
+}
+
+// groupResource defines the resource implementation.
+type groupResource struct {
+	client opnsense.Client
+}
+
+func (r *groupResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_auth_group"
+}
+
+func (r *groupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = groupResourceSchema()
+}
+
+func (r *groupResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = opnsense.NewClient(apiClient)
+}
+
+func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *groupResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := convertGroupSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse auth group, got error: %s", err))
+		return
+	}
+
+	id, err := r.client.Auth().AddGroup(ctx, resourceStruct)
+	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to create auth group, got error: %s", err))
+		return
+	}
+
+	data.Id = types.StringValue(id)
+
+	tflog.Trace(ctx, "created a resource")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *groupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *groupResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := r.client.Auth().GetGroup(ctx, data.Id.ValueString())
+	if err != nil {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
+			tflog.Warn(ctx, "auth group not present in remote, removing from state")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read auth group, got error: %s", err))
+		return
+	}
+
+	resourceModel, err := convertGroupStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read auth group, got error: %s", err))
+		return
+	}
+
+	resourceModel.Id = data.Id
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}
+
+func (r *groupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *groupResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := convertGroupSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse auth group, got error: %s", err))
+		return
+	}
+
+	err = r.client.Auth().UpdateGroup(ctx, data.Id.ValueString(), resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to update auth group, got error: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *groupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *groupResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.Auth().DeleteGroup(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to delete auth group, got error: %s", err))
+		return
+	}
+}
+
+func (r *groupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/service/auth/group_resource_test.go
+++ b/internal/service/auth/group_resource_test.go
@@ -1,0 +1,49 @@
+package auth_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/browningluke/terraform-provider-opnsense/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccAuthGroupResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccAuthGroupResourceConfig("testgroup_tf", "Test group"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_auth_group.test", "name", "testgroup_tf"),
+					resource.TestCheckResourceAttr("opnsense_auth_group.test", "description", "Test group"),
+					resource.TestCheckResourceAttrSet("opnsense_auth_group.test", "id"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "opnsense_auth_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update and Read testing
+			{
+				Config: testAccAuthGroupResourceConfig("testgroup_tf", "Updated group description"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_auth_group.test", "description", "Updated group description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAuthGroupResourceConfig(name, description string) string {
+	return fmt.Sprintf(`
+resource "opnsense_auth_group" "test" {
+  name        = %[1]q
+  description = %[2]q
+}
+`, name, description)
+}

--- a/internal/service/auth/group_schema.go
+++ b/internal/service/auth/group_schema.go
@@ -1,0 +1,159 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/auth"
+	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// groupResourceModel describes the resource data model.
+type groupResourceModel struct {
+	Name           types.String `tfsdk:"name"`
+	Description    types.String `tfsdk:"description"`
+	Scope          types.String `tfsdk:"scope"`
+	Privilege      types.Set    `tfsdk:"privilege"`
+	Member         types.String `tfsdk:"member"`
+	SourceNetworks types.String `tfsdk:"source_networks"`
+
+	GroupId types.String `tfsdk:"group_id"`
+	Id      types.String `tfsdk:"id"`
+}
+
+func groupResourceSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "Manages an OPNsense auth group.",
+
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The name of the group.",
+				Required:            true,
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Description for this group.",
+				Optional:            true,
+			},
+			"scope": schema.StringAttribute{
+				MarkdownDescription: "The group scope.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"privilege": schema.SetAttribute{
+				MarkdownDescription: "Set of privileges assigned to this group. Defaults to `[]`.",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"member": schema.StringAttribute{
+				MarkdownDescription: "Group member.",
+				Optional:            true,
+			},
+			"source_networks": schema.StringAttribute{
+				MarkdownDescription: "Source networks.",
+				Optional:            true,
+			},
+			"group_id": schema.StringAttribute{
+				MarkdownDescription: "The numeric group ID (GID).",
+				Computed:            true,
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "UUID of the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func groupDataSourceSchema() dschema.Schema {
+	return dschema.Schema{
+		MarkdownDescription: "Reads an OPNsense auth group.",
+
+		Attributes: map[string]dschema.Attribute{
+			"id": dschema.StringAttribute{
+				MarkdownDescription: "UUID of the resource.",
+				Required:            true,
+			},
+			"name": dschema.StringAttribute{
+				MarkdownDescription: "The name of the group.",
+				Computed:            true,
+			},
+			"description": dschema.StringAttribute{
+				MarkdownDescription: "Description for this group.",
+				Computed:            true,
+			},
+			"scope": dschema.StringAttribute{
+				MarkdownDescription: "The group scope.",
+				Computed:            true,
+			},
+			"privilege": dschema.SetAttribute{
+				MarkdownDescription: "Set of privileges assigned to this group.",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+			"member": dschema.StringAttribute{
+				MarkdownDescription: "Group member.",
+				Computed:            true,
+			},
+			"source_networks": dschema.StringAttribute{
+				MarkdownDescription: "Source networks.",
+				Computed:            true,
+			},
+			"group_id": dschema.StringAttribute{
+				MarkdownDescription: "The numeric group ID (GID).",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func convertGroupSchemaToStruct(d *groupResourceModel) (*auth.Group, error) {
+	// Parse 'Privilege'
+	var privilegeList []string
+	d.Privilege.ElementsAs(context.Background(), &privilegeList, false)
+
+	return &auth.Group{
+		Name:           d.Name.ValueString(),
+		Description:    d.Description.ValueString(),
+		Scope:          d.Scope.ValueString(),
+		Privilege:      privilegeList,
+		Member:         api.SelectedMap(d.Member.ValueString()),
+		SourceNetworks: api.SelectedMap(d.SourceNetworks.ValueString()),
+	}, nil
+}
+
+func convertGroupStructToSchema(d *auth.Group) (*groupResourceModel, error) {
+	model := &groupResourceModel{
+		Name:           types.StringValue(d.Name),
+		Description:    tools.StringOrNull(d.Description),
+		Scope:          types.StringValue(d.Scope),
+		Member:         tools.StringOrNull(d.Member.String()),
+		SourceNetworks: tools.StringOrNull(d.SourceNetworks.String()),
+		GroupId:        tools.StringOrNull(d.GroupId),
+	}
+
+	// Parse 'Privilege'
+	var privilegeList []attr.Value
+	for _, i := range d.Privilege {
+		if i == "" {
+			continue
+		}
+		privilegeList = append(privilegeList, basetypes.NewStringValue(i))
+	}
+	privilegeTypeList, _ := types.SetValue(types.StringType, privilegeList)
+	model.Privilege = privilegeTypeList
+
+	return model, nil
+}

--- a/internal/service/auth/user_data_source.go
+++ b/internal/service/auth/user_data_source.go
@@ -1,0 +1,76 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ datasource.DataSource = &userDataSource{}
+var _ datasource.DataSourceWithConfigure = &userDataSource{}
+
+func newUserDataSource() datasource.DataSource {
+	return &userDataSource{}
+}
+
+// userDataSource defines the data source implementation.
+type userDataSource struct {
+	client opnsense.Client
+}
+
+func (d *userDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_auth_user"
+}
+
+func (d *userDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = userDataSourceSchema()
+}
+
+func (d *userDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = opnsense.NewClient(apiClient)
+}
+
+func (d *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data *userResourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := d.client.Auth().GetUser(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read auth user, got error: %s", err))
+		return
+	}
+
+	resourceModel, err := convertUserStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read auth user, got error: %s", err))
+		return
+	}
+
+	resourceModel.Id = data.Id
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}

--- a/internal/service/auth/user_resource.go
+++ b/internal/service/auth/user_resource.go
@@ -1,0 +1,176 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &userResource{}
+var _ resource.ResourceWithConfigure = &userResource{}
+var _ resource.ResourceWithImportState = &userResource{}
+
+func newUserResource() resource.Resource {
+	return &userResource{}
+}
+
+// userResource defines the resource implementation.
+type userResource struct {
+	client opnsense.Client
+}
+
+func (r *userResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_auth_user"
+}
+
+func (r *userResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = userResourceSchema()
+}
+
+func (r *userResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = opnsense.NewClient(apiClient)
+}
+
+func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *userResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := convertUserSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse auth user, got error: %s", err))
+		return
+	}
+
+	id, err := r.client.Auth().AddUser(ctx, resourceStruct)
+	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to create auth user, got error: %s", err))
+		return
+	}
+
+	data.Id = types.StringValue(id)
+
+	tflog.Trace(ctx, "created a resource")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *userResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := r.client.Auth().GetUser(ctx, data.Id.ValueString())
+	if err != nil {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
+			tflog.Warn(ctx, "auth user not present in remote, removing from state")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read auth user, got error: %s", err))
+		return
+	}
+
+	resourceModel, err := convertUserStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read auth user, got error: %s", err))
+		return
+	}
+
+	resourceModel.Id = data.Id
+
+	// Preserve sensitive fields from state since they are not returned by the API
+	resourceModel.Password = data.Password
+	resourceModel.ScrambledPassword = data.ScrambledPassword
+	resourceModel.OtpSeed = data.OtpSeed
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}
+
+func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *userResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := convertUserSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse auth user, got error: %s", err))
+		return
+	}
+
+	err = r.client.Auth().UpdateUser(ctx, data.Id.ValueString(), resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to update auth user, got error: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *userResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.Auth().DeleteUser(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to delete auth user, got error: %s", err))
+		return
+	}
+}
+
+func (r *userResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/service/auth/user_resource_test.go
+++ b/internal/service/auth/user_resource_test.go
@@ -1,0 +1,55 @@
+package auth_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/browningluke/terraform-provider-opnsense/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccAuthUserResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccAuthUserResourceConfig("testuser_tf", "test@example.com", "Test User"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_auth_user.test", "name", "testuser_tf"),
+					resource.TestCheckResourceAttr("opnsense_auth_user.test", "email", "test@example.com"),
+					resource.TestCheckResourceAttr("opnsense_auth_user.test", "fullname", "Test User"),
+					resource.TestCheckResourceAttrSet("opnsense_auth_user.test", "id"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:            "opnsense_auth_user.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+			// Update and Read testing
+			{
+				Config: testAccAuthUserResourceConfig("testuser_tf", "updated@example.com", "Updated User"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_auth_user.test", "email", "updated@example.com"),
+					resource.TestCheckResourceAttr("opnsense_auth_user.test", "fullname", "Updated User"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccAuthUserResourceConfig(name, email, fullname string) string {
+	return fmt.Sprintf(`
+resource "opnsense_auth_user" "test" {
+  name     = %[1]q
+  email    = %[2]q
+  fullname = %[3]q
+  password = "TestPass123!"
+}
+`, name, email, fullname)
+}

--- a/internal/service/auth/user_schema.go
+++ b/internal/service/auth/user_schema.go
@@ -1,0 +1,305 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/auth"
+	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// userResourceModel describes the resource data model.
+type userResourceModel struct {
+	Disabled          types.Bool   `tfsdk:"disabled"`
+	Name              types.String `tfsdk:"name"`
+	Password          types.String `tfsdk:"password"`
+	ScrambledPassword types.String `tfsdk:"scrambled_password"`
+	Email             types.String `tfsdk:"email"`
+	Fullname          types.String `tfsdk:"fullname"`
+	Comment           types.String `tfsdk:"comment"`
+	OtpSeed           types.String `tfsdk:"otp_seed"`
+	AuthorizedKeys    types.String `tfsdk:"authorized_keys"`
+	Shell             types.String `tfsdk:"shell"`
+	Scope             types.String `tfsdk:"scope"`
+	Expires           types.String `tfsdk:"expires"`
+	LandingPage       types.String `tfsdk:"landing_page"`
+	ApiKeys           types.String `tfsdk:"api_keys"`
+	Language          types.String `tfsdk:"language"`
+	Dashboard         types.String `tfsdk:"dashboard"`
+	Privilege         types.Set    `tfsdk:"privilege"`
+	GroupMemberships  types.Set    `tfsdk:"group_memberships"`
+
+	UserId types.String `tfsdk:"user_id"`
+	Id     types.String `tfsdk:"id"`
+}
+
+func userResourceSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "Manages an OPNsense auth user.",
+
+		Attributes: map[string]schema.Attribute{
+			"disabled": schema.BoolAttribute{
+				MarkdownDescription: "Disable this user. Defaults to `false`.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The login name of the user.",
+				Required:            true,
+			},
+			"password": schema.StringAttribute{
+				MarkdownDescription: "The user password.",
+				Optional:            true,
+				Sensitive:           true,
+			},
+			"scrambled_password": schema.StringAttribute{
+				MarkdownDescription: "The scrambled (hashed) password.",
+				Optional:            true,
+				Sensitive:           true,
+			},
+			"email": schema.StringAttribute{
+				MarkdownDescription: "The user email address.",
+				Optional:            true,
+			},
+			"fullname": schema.StringAttribute{
+				MarkdownDescription: "The user full name (description).",
+				Optional:            true,
+			},
+			"comment": schema.StringAttribute{
+				MarkdownDescription: "Comment for this user.",
+				Optional:            true,
+			},
+			"otp_seed": schema.StringAttribute{
+				MarkdownDescription: "OTP seed for two-factor authentication.",
+				Optional:            true,
+				Sensitive:           true,
+			},
+			"authorized_keys": schema.StringAttribute{
+				MarkdownDescription: "SSH authorized keys.",
+				Optional:            true,
+			},
+			"shell": schema.StringAttribute{
+				MarkdownDescription: "The user login shell.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"scope": schema.StringAttribute{
+				MarkdownDescription: "The user scope.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"expires": schema.StringAttribute{
+				MarkdownDescription: "Account expiration date.",
+				Optional:            true,
+			},
+			"landing_page": schema.StringAttribute{
+				MarkdownDescription: "The landing page after login.",
+				Optional:            true,
+			},
+			"api_keys": schema.StringAttribute{
+				MarkdownDescription: "API keys for this user.",
+				Optional:            true,
+			},
+			"language": schema.StringAttribute{
+				MarkdownDescription: "The user language preference.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"dashboard": schema.StringAttribute{
+				MarkdownDescription: "Dashboard columns.",
+				Optional:            true,
+			},
+			"privilege": schema.SetAttribute{
+				MarkdownDescription: "Set of privileges assigned to this user. Defaults to `[]`.",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"group_memberships": schema.SetAttribute{
+				MarkdownDescription: "Set of group memberships for this user. Defaults to `[]`.",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"user_id": schema.StringAttribute{
+				MarkdownDescription: "The numeric user ID (UID).",
+				Computed:            true,
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "UUID of the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func userDataSourceSchema() dschema.Schema {
+	return dschema.Schema{
+		MarkdownDescription: "Reads an OPNsense auth user.",
+
+		Attributes: map[string]dschema.Attribute{
+			"id": dschema.StringAttribute{
+				MarkdownDescription: "UUID of the resource.",
+				Required:            true,
+			},
+			"disabled": dschema.BoolAttribute{
+				MarkdownDescription: "Whether this user is disabled.",
+				Computed:            true,
+			},
+			"name": dschema.StringAttribute{
+				MarkdownDescription: "The login name of the user.",
+				Computed:            true,
+			},
+			"email": dschema.StringAttribute{
+				MarkdownDescription: "The user email address.",
+				Computed:            true,
+			},
+			"fullname": dschema.StringAttribute{
+				MarkdownDescription: "The user full name (description).",
+				Computed:            true,
+			},
+			"comment": dschema.StringAttribute{
+				MarkdownDescription: "Comment for this user.",
+				Computed:            true,
+			},
+			"authorized_keys": dschema.StringAttribute{
+				MarkdownDescription: "SSH authorized keys.",
+				Computed:            true,
+			},
+			"shell": dschema.StringAttribute{
+				MarkdownDescription: "The user login shell.",
+				Computed:            true,
+			},
+			"scope": dschema.StringAttribute{
+				MarkdownDescription: "The user scope.",
+				Computed:            true,
+			},
+			"expires": dschema.StringAttribute{
+				MarkdownDescription: "Account expiration date.",
+				Computed:            true,
+			},
+			"landing_page": dschema.StringAttribute{
+				MarkdownDescription: "The landing page after login.",
+				Computed:            true,
+			},
+			"api_keys": dschema.StringAttribute{
+				MarkdownDescription: "API keys for this user.",
+				Computed:            true,
+			},
+			"language": dschema.StringAttribute{
+				MarkdownDescription: "The user language preference.",
+				Computed:            true,
+			},
+			"dashboard": dschema.StringAttribute{
+				MarkdownDescription: "Dashboard columns.",
+				Computed:            true,
+			},
+			"privilege": dschema.SetAttribute{
+				MarkdownDescription: "Set of privileges assigned to this user.",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+			"group_memberships": dschema.SetAttribute{
+				MarkdownDescription: "Set of group memberships for this user.",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+			"user_id": dschema.StringAttribute{
+				MarkdownDescription: "The numeric user ID (UID).",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func convertUserSchemaToStruct(d *userResourceModel) (*auth.User, error) {
+	// Parse 'Privilege'
+	var privilegeList []string
+	d.Privilege.ElementsAs(context.Background(), &privilegeList, false)
+
+	// Parse 'GroupMemberships'
+	var groupMembershipsList []string
+	d.GroupMemberships.ElementsAs(context.Background(), &groupMembershipsList, false)
+
+	return &auth.User{
+		Name:              d.Name.ValueString(),
+		Disabled:          tools.BoolToString(d.Disabled.ValueBool()),
+		Password:          d.Password.ValueString(),
+		ScrambledPassword: d.ScrambledPassword.ValueString(),
+		Email:             d.Email.ValueString(),
+		Fullname:          d.Fullname.ValueString(),
+		Comment:           d.Comment.ValueString(),
+		OtpSeed:           d.OtpSeed.ValueString(),
+		AuthorizedKeys:    d.AuthorizedKeys.ValueString(),
+		Shell:             api.SelectedMap(d.Shell.ValueString()),
+		Scope:             d.Scope.ValueString(),
+		Expires:           d.Expires.ValueString(),
+		LandingPage:       d.LandingPage.ValueString(),
+		ApiKeys:           d.ApiKeys.ValueString(),
+		Language:          api.SelectedMap(d.Language.ValueString()),
+		Dashboard:         d.Dashboard.ValueString(),
+		Privilege:         privilegeList,
+		GroupMemberships:  groupMembershipsList,
+	}, nil
+}
+
+func convertUserStructToSchema(d *auth.User) (*userResourceModel, error) {
+	model := &userResourceModel{
+		Disabled:          types.BoolValue(tools.StringToBool(d.Disabled)),
+		Name:              types.StringValue(d.Name),
+		Email:             tools.StringOrNull(d.Email),
+		Fullname:          tools.StringOrNull(d.Fullname),
+		Comment:           tools.StringOrNull(d.Comment),
+		OtpSeed:           tools.StringOrNull(d.OtpSeed),
+		AuthorizedKeys:    tools.StringOrNull(d.AuthorizedKeys),
+		Shell:             types.StringValue(d.Shell.String()),
+		Scope:             types.StringValue(d.Scope),
+		Expires:           tools.StringOrNull(d.Expires),
+		LandingPage:       tools.StringOrNull(d.LandingPage),
+		ApiKeys:           tools.StringOrNull(d.ApiKeys),
+		Language:          types.StringValue(d.Language.String()),
+		Dashboard:         tools.StringOrNull(d.Dashboard),
+		Password:          types.StringNull(),
+		ScrambledPassword: types.StringNull(),
+		UserId:            tools.StringOrNull(d.UserId),
+	}
+
+	// Parse 'Privilege'
+	var privilegeList []attr.Value
+	for _, i := range d.Privilege {
+		if i == "" {
+			continue
+		}
+		privilegeList = append(privilegeList, basetypes.NewStringValue(i))
+	}
+	privilegeTypeList, _ := types.SetValue(types.StringType, privilegeList)
+	model.Privilege = privilegeTypeList
+
+	// Parse 'GroupMemberships'
+	var groupMembershipsList []attr.Value
+	for _, i := range d.GroupMemberships {
+		if i == "" {
+			continue
+		}
+		groupMembershipsList = append(groupMembershipsList, basetypes.NewStringValue(i))
+	}
+	groupMembershipsTypeList, _ := types.SetValue(types.StringType, groupMembershipsList)
+	model.GroupMemberships = groupMembershipsTypeList
+
+	return model, nil
+}

--- a/internal/service/bind/acl_data_source.go
+++ b/internal/service/bind/acl_data_source.go
@@ -1,0 +1,74 @@
+package bind
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+var _ datasource.DataSource = &aclDataSource{}
+var _ datasource.DataSourceWithConfigure = &aclDataSource{}
+
+func newAclDataSource() datasource.DataSource {
+	return &aclDataSource{}
+}
+
+type aclDataSource struct {
+	client opnsense.Client
+}
+
+func (d *aclDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_bind_acl"
+}
+
+func (d *aclDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = aclDataSourceSchema()
+}
+
+func (d *aclDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = opnsense.NewClient(apiClient)
+}
+
+func (d *aclDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data *aclResourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := d.client.Bind().GetAcl(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read bind acl, got error: %s", err))
+		return
+	}
+
+	resourceModel, err := convertAclStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read bind acl, got error: %s", err))
+		return
+	}
+
+	resourceModel.Id = data.Id
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}

--- a/internal/service/bind/acl_resource.go
+++ b/internal/service/bind/acl_resource.go
@@ -1,0 +1,169 @@
+package bind
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &aclResource{}
+var _ resource.ResourceWithConfigure = &aclResource{}
+var _ resource.ResourceWithImportState = &aclResource{}
+
+func newAclResource() resource.Resource {
+	return &aclResource{}
+}
+
+type aclResource struct {
+	client opnsense.Client
+}
+
+func (r *aclResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_bind_acl"
+}
+
+func (r *aclResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = aclResourceSchema()
+}
+
+func (r *aclResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = opnsense.NewClient(apiClient)
+}
+
+func (r *aclResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *aclResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := convertAclSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse bind acl, got error: %s", err))
+		return
+	}
+
+	id, err := r.client.Bind().AddAcl(ctx, resourceStruct)
+	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to create bind acl, got error: %s", err))
+		return
+	}
+
+	data.Id = types.StringValue(id)
+
+	tflog.Trace(ctx, "created a resource")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *aclResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *aclResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := r.client.Bind().GetAcl(ctx, data.Id.ValueString())
+	if err != nil {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
+			tflog.Warn(ctx, "bind acl not present in remote, removing from state")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read bind acl, got error: %s", err))
+		return
+	}
+
+	resourceModel, err := convertAclStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read bind acl, got error: %s", err))
+		return
+	}
+
+	resourceModel.Id = data.Id
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}
+
+func (r *aclResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *aclResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := convertAclSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse bind acl, got error: %s", err))
+		return
+	}
+
+	err = r.client.Bind().UpdateAcl(ctx, data.Id.ValueString(), resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to update bind acl, got error: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *aclResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *aclResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.Bind().DeleteAcl(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to delete bind acl, got error: %s", err))
+		return
+	}
+}
+
+func (r *aclResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/service/bind/acl_resource_test.go
+++ b/internal/service/bind/acl_resource_test.go
@@ -1,0 +1,47 @@
+package bind_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/browningluke/terraform-provider-opnsense/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccBindAclResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBindAclResourceConfig("test_acl", "1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_bind_acl.test", "name", "test_acl"),
+					resource.TestCheckResourceAttr("opnsense_bind_acl.test", "enabled", "1"),
+					resource.TestCheckResourceAttrSet("opnsense_bind_acl.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "opnsense_bind_acl.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBindAclResourceConfig("test_acl_upd", "0"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_bind_acl.test", "name", "test_acl_upd"),
+					resource.TestCheckResourceAttr("opnsense_bind_acl.test", "enabled", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBindAclResourceConfig(name, enabled string) string {
+	return fmt.Sprintf(`
+resource "opnsense_bind_acl" "test" {
+  name    = %[1]q
+  enabled = %[2]q
+}
+`, name, enabled)
+}

--- a/internal/service/bind/acl_schema.go
+++ b/internal/service/bind/acl_schema.go
@@ -1,0 +1,115 @@
+package bind
+
+import (
+	"context"
+
+	"github.com/browningluke/opnsense-go/pkg/bind"
+	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// aclResourceModel describes the resource data model.
+type aclResourceModel struct {
+	Enabled  types.Bool   `tfsdk:"enabled"`
+	Name     types.String `tfsdk:"name"`
+	Networks types.Set    `tfsdk:"networks"`
+
+	Id types.String `tfsdk:"id"`
+}
+
+func aclResourceSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "Manages an OPNsense BIND ACL.",
+
+		Attributes: map[string]schema.Attribute{
+			"enabled": schema.BoolAttribute{
+				MarkdownDescription: "Enable this ACL. Defaults to `true`.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(true),
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The name of the ACL.",
+				Required:            true,
+			},
+			"networks": schema.SetAttribute{
+				MarkdownDescription: "Set of networks for this ACL. Defaults to `[]`.",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "UUID of the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func aclDataSourceSchema() dschema.Schema {
+	return dschema.Schema{
+		MarkdownDescription: "Reads an OPNsense BIND ACL.",
+
+		Attributes: map[string]dschema.Attribute{
+			"id": dschema.StringAttribute{
+				MarkdownDescription: "UUID of the resource.",
+				Required:            true,
+			},
+			"enabled": dschema.BoolAttribute{
+				MarkdownDescription: "Whether this ACL is enabled.",
+				Computed:            true,
+			},
+			"name": dschema.StringAttribute{
+				MarkdownDescription: "The name of the ACL.",
+				Computed:            true,
+			},
+			"networks": dschema.SetAttribute{
+				MarkdownDescription: "Set of networks for this ACL.",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+		},
+	}
+}
+
+func convertAclSchemaToStruct(d *aclResourceModel) (*bind.Acl, error) {
+	var networksList []string
+	d.Networks.ElementsAs(context.Background(), &networksList, false)
+
+	return &bind.Acl{
+		Enabled:  tools.BoolToString(d.Enabled.ValueBool()),
+		Name:     d.Name.ValueString(),
+		Networks: networksList,
+	}, nil
+}
+
+func convertAclStructToSchema(d *bind.Acl) (*aclResourceModel, error) {
+	model := &aclResourceModel{
+		Enabled: types.BoolValue(tools.StringToBool(d.Enabled)),
+		Name:    types.StringValue(d.Name),
+	}
+
+	var networksList []attr.Value
+	for _, i := range d.Networks {
+		if i == "" {
+			continue
+		}
+		networksList = append(networksList, basetypes.NewStringValue(i))
+	}
+	networksTypeList, _ := types.SetValue(types.StringType, networksList)
+	model.Networks = networksTypeList
+
+	return model, nil
+}

--- a/internal/service/bind/exports.go
+++ b/internal/service/bind/exports.go
@@ -1,23 +1,24 @@
-package interfaces
+package bind
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 func Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		newAssignResource,
-		newVipResource,
-		newVlanResource,
+		newAclResource,
+		newPrimaryDomainResource,
+		newRecordResource,
 	}
 }
 
 func DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		newAssignDataSource,
-		newVipDataSource,
-		newVlanDataSource,
+		newAclDataSource,
+		newPrimaryDomainDataSource,
+		newRecordDataSource,
 	}
 }

--- a/internal/service/bind/primary_domain_data_source.go
+++ b/internal/service/bind/primary_domain_data_source.go
@@ -1,0 +1,74 @@
+package bind
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+var _ datasource.DataSource = &primaryDomainDataSource{}
+var _ datasource.DataSourceWithConfigure = &primaryDomainDataSource{}
+
+func newPrimaryDomainDataSource() datasource.DataSource {
+	return &primaryDomainDataSource{}
+}
+
+type primaryDomainDataSource struct {
+	client opnsense.Client
+}
+
+func (d *primaryDomainDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_bind_primary_domain"
+}
+
+func (d *primaryDomainDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = primaryDomainDataSourceSchema()
+}
+
+func (d *primaryDomainDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = opnsense.NewClient(apiClient)
+}
+
+func (d *primaryDomainDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data *primaryDomainResourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := d.client.Bind().GetPrimaryDomain(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read bind primary domain, got error: %s", err))
+		return
+	}
+
+	resourceModel, err := convertPrimaryDomainStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read bind primary domain, got error: %s", err))
+		return
+	}
+
+	resourceModel.Id = data.Id
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}

--- a/internal/service/bind/primary_domain_resource.go
+++ b/internal/service/bind/primary_domain_resource.go
@@ -1,0 +1,169 @@
+package bind
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &primaryDomainResource{}
+var _ resource.ResourceWithConfigure = &primaryDomainResource{}
+var _ resource.ResourceWithImportState = &primaryDomainResource{}
+
+func newPrimaryDomainResource() resource.Resource {
+	return &primaryDomainResource{}
+}
+
+type primaryDomainResource struct {
+	client opnsense.Client
+}
+
+func (r *primaryDomainResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_bind_primary_domain"
+}
+
+func (r *primaryDomainResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = primaryDomainResourceSchema()
+}
+
+func (r *primaryDomainResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = opnsense.NewClient(apiClient)
+}
+
+func (r *primaryDomainResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *primaryDomainResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := convertPrimaryDomainSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse bind primary domain, got error: %s", err))
+		return
+	}
+
+	id, err := r.client.Bind().AddPrimaryDomain(ctx, resourceStruct)
+	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to create bind primary domain, got error: %s", err))
+		return
+	}
+
+	data.Id = types.StringValue(id)
+
+	tflog.Trace(ctx, "created a resource")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *primaryDomainResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *primaryDomainResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := r.client.Bind().GetPrimaryDomain(ctx, data.Id.ValueString())
+	if err != nil {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
+			tflog.Warn(ctx, "bind primary domain not present in remote, removing from state")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read bind primary domain, got error: %s", err))
+		return
+	}
+
+	resourceModel, err := convertPrimaryDomainStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read bind primary domain, got error: %s", err))
+		return
+	}
+
+	resourceModel.Id = data.Id
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}
+
+func (r *primaryDomainResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *primaryDomainResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := convertPrimaryDomainSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse bind primary domain, got error: %s", err))
+		return
+	}
+
+	err = r.client.Bind().UpdatePrimaryDomain(ctx, data.Id.ValueString(), resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to update bind primary domain, got error: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *primaryDomainResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *primaryDomainResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.Bind().DeletePrimaryDomain(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to delete bind primary domain, got error: %s", err))
+		return
+	}
+}
+
+func (r *primaryDomainResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/service/bind/primary_domain_resource_test.go
+++ b/internal/service/bind/primary_domain_resource_test.go
@@ -1,0 +1,51 @@
+package bind_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/browningluke/terraform-provider-opnsense/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccBindPrimaryDomainResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBindPrimaryDomainResourceConfig("test.example.com", "1", "admin@test.example.com", "ns1.test.example.com"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_bind_primary_domain.test", "domain_name", "test.example.com"),
+					resource.TestCheckResourceAttr("opnsense_bind_primary_domain.test", "enabled", "1"),
+					resource.TestCheckResourceAttr("opnsense_bind_primary_domain.test", "mail_admin", "admin@test.example.com"),
+					resource.TestCheckResourceAttr("opnsense_bind_primary_domain.test", "dns_server", "ns1.test.example.com"),
+					resource.TestCheckResourceAttrSet("opnsense_bind_primary_domain.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "opnsense_bind_primary_domain.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBindPrimaryDomainResourceConfig("test.example.com", "1", "postmaster@test.example.com", "ns2.test.example.com"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_bind_primary_domain.test", "mail_admin", "postmaster@test.example.com"),
+					resource.TestCheckResourceAttr("opnsense_bind_primary_domain.test", "dns_server", "ns2.test.example.com"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBindPrimaryDomainResourceConfig(domainName, enabled, mailAdmin, dnsServer string) string {
+	return fmt.Sprintf(`
+resource "opnsense_bind_primary_domain" "test" {
+  domain_name = %[1]q
+  enabled     = %[2]q
+  mail_admin  = %[3]q
+  dns_server  = %[4]q
+}
+`, domainName, enabled, mailAdmin, dnsServer)
+}

--- a/internal/service/bind/primary_domain_schema.go
+++ b/internal/service/bind/primary_domain_schema.go
@@ -1,0 +1,218 @@
+package bind
+
+import (
+	"context"
+
+	"github.com/browningluke/opnsense-go/pkg/bind"
+	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+type primaryDomainResourceModel struct {
+	Enabled       types.Bool   `tfsdk:"enabled"`
+	DomainName    types.String `tfsdk:"domain_name"`
+	AllowTransfer types.Set    `tfsdk:"allow_transfer"`
+	AllowQuery    types.Set    `tfsdk:"allow_query"`
+	TTL           types.String `tfsdk:"ttl"`
+	Refresh       types.String `tfsdk:"refresh"`
+	Retry         types.String `tfsdk:"retry"`
+	Expire        types.String `tfsdk:"expire"`
+	Negative      types.String `tfsdk:"negative"`
+	MailAdmin     types.String `tfsdk:"mail_admin"`
+	DnsServer     types.String `tfsdk:"dns_server"`
+
+	Id types.String `tfsdk:"id"`
+}
+
+func primaryDomainResourceSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "Manages an OPNsense BIND primary domain.",
+
+		Attributes: map[string]schema.Attribute{
+			"enabled": schema.BoolAttribute{
+				MarkdownDescription: "Enable this primary domain. Defaults to `true`.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(true),
+			},
+			"domain_name": schema.StringAttribute{
+				MarkdownDescription: "The domain name.",
+				Required:            true,
+			},
+			"allow_transfer": schema.SetAttribute{
+				MarkdownDescription: "ACLs allowed to transfer. Defaults to `[]`.",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"allow_query": schema.SetAttribute{
+				MarkdownDescription: "ACLs allowed to query. Defaults to `[]`.",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"ttl": schema.StringAttribute{
+				MarkdownDescription: "Time to live.",
+				Optional:            true,
+			},
+			"refresh": schema.StringAttribute{
+				MarkdownDescription: "Refresh interval.",
+				Optional:            true,
+			},
+			"retry": schema.StringAttribute{
+				MarkdownDescription: "Retry interval.",
+				Optional:            true,
+			},
+			"expire": schema.StringAttribute{
+				MarkdownDescription: "Expire time.",
+				Optional:            true,
+			},
+			"negative": schema.StringAttribute{
+				MarkdownDescription: "Negative cache TTL.",
+				Optional:            true,
+			},
+			"mail_admin": schema.StringAttribute{
+				MarkdownDescription: "Mail admin address.",
+				Optional:            true,
+			},
+			"dns_server": schema.StringAttribute{
+				MarkdownDescription: "DNS server hostname.",
+				Optional:            true,
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "UUID of the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func primaryDomainDataSourceSchema() dschema.Schema {
+	return dschema.Schema{
+		MarkdownDescription: "Reads an OPNsense BIND primary domain.",
+
+		Attributes: map[string]dschema.Attribute{
+			"id": dschema.StringAttribute{
+				MarkdownDescription: "UUID of the resource.",
+				Required:            true,
+			},
+			"enabled": dschema.BoolAttribute{
+				MarkdownDescription: "Whether this primary domain is enabled.",
+				Computed:            true,
+			},
+			"domain_name": dschema.StringAttribute{
+				MarkdownDescription: "The domain name.",
+				Computed:            true,
+			},
+			"allow_transfer": dschema.SetAttribute{
+				MarkdownDescription: "ACLs allowed to transfer.",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+			"allow_query": dschema.SetAttribute{
+				MarkdownDescription: "ACLs allowed to query.",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+			"ttl": dschema.StringAttribute{
+				MarkdownDescription: "Time to live.",
+				Computed:            true,
+			},
+			"refresh": dschema.StringAttribute{
+				MarkdownDescription: "Refresh interval.",
+				Computed:            true,
+			},
+			"retry": dschema.StringAttribute{
+				MarkdownDescription: "Retry interval.",
+				Computed:            true,
+			},
+			"expire": dschema.StringAttribute{
+				MarkdownDescription: "Expire time.",
+				Computed:            true,
+			},
+			"negative": dschema.StringAttribute{
+				MarkdownDescription: "Negative cache TTL.",
+				Computed:            true,
+			},
+			"mail_admin": dschema.StringAttribute{
+				MarkdownDescription: "Mail admin address.",
+				Computed:            true,
+			},
+			"dns_server": dschema.StringAttribute{
+				MarkdownDescription: "DNS server hostname.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func convertPrimaryDomainSchemaToStruct(d *primaryDomainResourceModel) (*bind.PrimaryDomain, error) {
+	var allowTransferList []string
+	d.AllowTransfer.ElementsAs(context.Background(), &allowTransferList, false)
+
+	var allowQueryList []string
+	d.AllowQuery.ElementsAs(context.Background(), &allowQueryList, false)
+
+	return &bind.PrimaryDomain{
+		Enabled:       tools.BoolToString(d.Enabled.ValueBool()),
+		DomainName:    d.DomainName.ValueString(),
+		AllowTransfer: allowTransferList,
+		AllowQuery:    allowQueryList,
+		TimeToLive:    d.TTL.ValueString(),
+		Refresh:       d.Refresh.ValueString(),
+		Retry:         d.Retry.ValueString(),
+		Expire:        d.Expire.ValueString(),
+		Negative:      d.Negative.ValueString(),
+		MailAdmin:     d.MailAdmin.ValueString(),
+		DnsServer:     d.DnsServer.ValueString(),
+	}, nil
+}
+
+func convertPrimaryDomainStructToSchema(d *bind.PrimaryDomain) (*primaryDomainResourceModel, error) {
+	model := &primaryDomainResourceModel{
+		Enabled:    types.BoolValue(tools.StringToBool(d.Enabled)),
+		DomainName: types.StringValue(d.DomainName),
+		TTL:        tools.StringOrNull(d.TimeToLive),
+		Refresh:    tools.StringOrNull(d.Refresh),
+		Retry:      tools.StringOrNull(d.Retry),
+		Expire:     tools.StringOrNull(d.Expire),
+		Negative:   tools.StringOrNull(d.Negative),
+		MailAdmin:  tools.StringOrNull(d.MailAdmin),
+		DnsServer:  tools.StringOrNull(d.DnsServer),
+	}
+
+	var allowTransferList []attr.Value
+	for _, i := range d.AllowTransfer {
+		if i == "" {
+			continue
+		}
+		allowTransferList = append(allowTransferList, basetypes.NewStringValue(i))
+	}
+	allowTransferTypeList, _ := types.SetValue(types.StringType, allowTransferList)
+	model.AllowTransfer = allowTransferTypeList
+
+	var allowQueryList []attr.Value
+	for _, i := range d.AllowQuery {
+		if i == "" {
+			continue
+		}
+		allowQueryList = append(allowQueryList, basetypes.NewStringValue(i))
+	}
+	allowQueryTypeList, _ := types.SetValue(types.StringType, allowQueryList)
+	model.AllowQuery = allowQueryTypeList
+
+	return model, nil
+}

--- a/internal/service/bind/record_data_source.go
+++ b/internal/service/bind/record_data_source.go
@@ -1,0 +1,74 @@
+package bind
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+var _ datasource.DataSource = &recordDataSource{}
+var _ datasource.DataSourceWithConfigure = &recordDataSource{}
+
+func newRecordDataSource() datasource.DataSource {
+	return &recordDataSource{}
+}
+
+type recordDataSource struct {
+	client opnsense.Client
+}
+
+func (d *recordDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_bind_record"
+}
+
+func (d *recordDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = recordDataSourceSchema()
+}
+
+func (d *recordDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = opnsense.NewClient(apiClient)
+}
+
+func (d *recordDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data *recordResourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := d.client.Bind().GetRecord(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read bind record, got error: %s", err))
+		return
+	}
+
+	resourceModel, err := convertRecordStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read bind record, got error: %s", err))
+		return
+	}
+
+	resourceModel.Id = data.Id
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}

--- a/internal/service/bind/record_resource.go
+++ b/internal/service/bind/record_resource.go
@@ -1,0 +1,169 @@
+package bind
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &recordResource{}
+var _ resource.ResourceWithConfigure = &recordResource{}
+var _ resource.ResourceWithImportState = &recordResource{}
+
+func newRecordResource() resource.Resource {
+	return &recordResource{}
+}
+
+type recordResource struct {
+	client opnsense.Client
+}
+
+func (r *recordResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_bind_record"
+}
+
+func (r *recordResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = recordResourceSchema()
+}
+
+func (r *recordResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = opnsense.NewClient(apiClient)
+}
+
+func (r *recordResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *recordResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := convertRecordSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse bind record, got error: %s", err))
+		return
+	}
+
+	id, err := r.client.Bind().AddRecord(ctx, resourceStruct)
+	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to create bind record, got error: %s", err))
+		return
+	}
+
+	data.Id = types.StringValue(id)
+
+	tflog.Trace(ctx, "created a resource")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *recordResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *recordResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := r.client.Bind().GetRecord(ctx, data.Id.ValueString())
+	if err != nil {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
+			tflog.Warn(ctx, "bind record not present in remote, removing from state")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read bind record, got error: %s", err))
+		return
+	}
+
+	resourceModel, err := convertRecordStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read bind record, got error: %s", err))
+		return
+	}
+
+	resourceModel.Id = data.Id
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}
+
+func (r *recordResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *recordResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := convertRecordSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse bind record, got error: %s", err))
+		return
+	}
+
+	err = r.client.Bind().UpdateRecord(ctx, data.Id.ValueString(), resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to update bind record, got error: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *recordResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *recordResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.Bind().DeleteRecord(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to delete bind record, got error: %s", err))
+		return
+	}
+}
+
+func (r *recordResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/service/bind/record_resource_test.go
+++ b/internal/service/bind/record_resource_test.go
@@ -1,0 +1,50 @@
+package bind_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/browningluke/terraform-provider-opnsense/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccBindRecordResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBindRecordResourceConfig("www", "A", "192.168.1.1", "1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_bind_record.test", "name", "www"),
+					resource.TestCheckResourceAttr("opnsense_bind_record.test", "type", "A"),
+					resource.TestCheckResourceAttr("opnsense_bind_record.test", "value", "192.168.1.1"),
+					resource.TestCheckResourceAttr("opnsense_bind_record.test", "enabled", "1"),
+					resource.TestCheckResourceAttrSet("opnsense_bind_record.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "opnsense_bind_record.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBindRecordResourceConfig("www", "A", "192.168.1.2", "1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_bind_record.test", "value", "192.168.1.2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBindRecordResourceConfig(name, recordType, value, enabled string) string {
+	return fmt.Sprintf(`
+resource "opnsense_bind_record" "test" {
+  name    = %[1]q
+  type    = %[2]q
+  value   = %[3]q
+  enabled = %[4]q
+}
+`, name, recordType, value, enabled)
+}

--- a/internal/service/bind/record_schema.go
+++ b/internal/service/bind/record_schema.go
@@ -1,0 +1,114 @@
+package bind
+
+import (
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/bind"
+	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type recordResourceModel struct {
+	Enabled types.Bool   `tfsdk:"enabled"`
+	Name    types.String `tfsdk:"name"`
+	Type    types.String `tfsdk:"type"`
+	Value   types.String `tfsdk:"value"`
+	Domain  types.String `tfsdk:"domain"`
+
+	Id types.String `tfsdk:"id"`
+}
+
+func recordResourceSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "Manages an OPNsense BIND record.",
+
+		Attributes: map[string]schema.Attribute{
+			"enabled": schema.BoolAttribute{
+				MarkdownDescription: "Enable this record. Defaults to `true`.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(true),
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "The record name.",
+				Required:            true,
+			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "The record type (e.g. A, AAAA, CNAME, MX, etc.).",
+				Required:            true,
+			},
+			"value": schema.StringAttribute{
+				MarkdownDescription: "The record value.",
+				Required:            true,
+			},
+			"domain": schema.StringAttribute{
+				MarkdownDescription: "The domain this record belongs to.",
+				Required:            true,
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "UUID of the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func recordDataSourceSchema() dschema.Schema {
+	return dschema.Schema{
+		MarkdownDescription: "Reads an OPNsense BIND record.",
+
+		Attributes: map[string]dschema.Attribute{
+			"id": dschema.StringAttribute{
+				MarkdownDescription: "UUID of the resource.",
+				Required:            true,
+			},
+			"enabled": dschema.BoolAttribute{
+				MarkdownDescription: "Whether this record is enabled.",
+				Computed:            true,
+			},
+			"name": dschema.StringAttribute{
+				MarkdownDescription: "The record name.",
+				Computed:            true,
+			},
+			"type": dschema.StringAttribute{
+				MarkdownDescription: "The record type.",
+				Computed:            true,
+			},
+			"value": dschema.StringAttribute{
+				MarkdownDescription: "The record value.",
+				Computed:            true,
+			},
+			"domain": dschema.StringAttribute{
+				MarkdownDescription: "The domain this record belongs to.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func convertRecordSchemaToStruct(d *recordResourceModel) (*bind.Record, error) {
+	return &bind.Record{
+		Enabled: tools.BoolToString(d.Enabled.ValueBool()),
+		Name:    d.Name.ValueString(),
+		Type:    api.SelectedMap(d.Type.ValueString()),
+		Value:   d.Value.ValueString(),
+		Domain:  api.SelectedMap(d.Domain.ValueString()),
+	}, nil
+}
+
+func convertRecordStructToSchema(d *bind.Record) (*recordResourceModel, error) {
+	return &recordResourceModel{
+		Enabled: types.BoolValue(tools.StringToBool(d.Enabled)),
+		Name:    types.StringValue(d.Name),
+		Type:    types.StringValue(d.Type.String()),
+		Value:   types.StringValue(d.Value),
+		Domain:  types.StringValue(d.Domain.String()),
+	}, nil
+}

--- a/internal/service/dnsmasq/boot_data_source.go
+++ b/internal/service/dnsmasq/boot_data_source.go
@@ -1,0 +1,74 @@
+package dnsmasq
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+var _ datasource.DataSource = &bootDataSource{}
+var _ datasource.DataSourceWithConfigure = &bootDataSource{}
+
+func newBootDataSource() datasource.DataSource {
+	return &bootDataSource{}
+}
+
+type bootDataSource struct {
+	client opnsense.Client
+}
+
+func (d *bootDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dnsmasq_boot"
+}
+
+func (d *bootDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = bootDataSourceSchema()
+}
+
+func (d *bootDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = opnsense.NewClient(apiClient)
+}
+
+func (d *bootDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data *bootResourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := d.client.Dnsmasq().GetBoot(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read dnsmasq boot, got error: %s", err))
+		return
+	}
+
+	resourceModel, err := convertBootStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read dnsmasq boot, got error: %s", err))
+		return
+	}
+
+	resourceModel.Id = data.Id
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}

--- a/internal/service/dnsmasq/boot_resource.go
+++ b/internal/service/dnsmasq/boot_resource.go
@@ -1,0 +1,169 @@
+package dnsmasq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &bootResource{}
+var _ resource.ResourceWithConfigure = &bootResource{}
+var _ resource.ResourceWithImportState = &bootResource{}
+
+func newBootResource() resource.Resource {
+	return &bootResource{}
+}
+
+type bootResource struct {
+	client opnsense.Client
+}
+
+func (r *bootResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dnsmasq_boot"
+}
+
+func (r *bootResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = bootResourceSchema()
+}
+
+func (r *bootResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = opnsense.NewClient(apiClient)
+}
+
+func (r *bootResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *bootResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := convertBootSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse dnsmasq boot, got error: %s", err))
+		return
+	}
+
+	id, err := r.client.Dnsmasq().AddBoot(ctx, resourceStruct)
+	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to create dnsmasq boot, got error: %s", err))
+		return
+	}
+
+	data.Id = types.StringValue(id)
+
+	tflog.Trace(ctx, "created a resource")
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *bootResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *bootResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := r.client.Dnsmasq().GetBoot(ctx, data.Id.ValueString())
+	if err != nil {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
+			tflog.Warn(ctx, "dnsmasq boot not present in remote, removing from state")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read dnsmasq boot, got error: %s", err))
+		return
+	}
+
+	resourceModel, err := convertBootStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read dnsmasq boot, got error: %s", err))
+		return
+	}
+
+	resourceModel.Id = data.Id
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}
+
+func (r *bootResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *bootResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resourceStruct, err := convertBootSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to parse dnsmasq boot, got error: %s", err))
+		return
+	}
+
+	err = r.client.Dnsmasq().UpdateBoot(ctx, data.Id.ValueString(), resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to update dnsmasq boot, got error: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *bootResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *bootResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.Dnsmasq().DeleteBoot(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to delete dnsmasq boot, got error: %s", err))
+		return
+	}
+}
+
+func (r *bootResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/service/dnsmasq/boot_resource_test.go
+++ b/internal/service/dnsmasq/boot_resource_test.go
@@ -1,0 +1,52 @@
+package dnsmasq_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/browningluke/terraform-provider-opnsense/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDnsmasqBootResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsmasqBootResourceConfig("pxelinux.0", "tftp-server", "192.168.1.1", "Test PXE boot"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_boot.test", "filename", "pxelinux.0"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_boot.test", "servername", "tftp-server"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_boot.test", "server_address", "192.168.1.1"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_boot.test", "description", "Test PXE boot"),
+					resource.TestCheckResourceAttrSet("opnsense_dnsmasq_boot.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "opnsense_dnsmasq_boot.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDnsmasqBootResourceConfig("pxelinux.0", "tftp-server-updated", "192.168.1.2", "Updated PXE boot"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_boot.test", "servername", "tftp-server-updated"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_boot.test", "server_address", "192.168.1.2"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_boot.test", "description", "Updated PXE boot"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDnsmasqBootResourceConfig(filename, servername, serverAddress, description string) string {
+	return fmt.Sprintf(`
+resource "opnsense_dnsmasq_boot" "test" {
+  filename       = %[1]q
+  servername     = %[2]q
+  server_address = %[3]q
+  description    = %[4]q
+}
+`, filename, servername, serverAddress, description)
+}

--- a/internal/service/dnsmasq/boot_schema.go
+++ b/internal/service/dnsmasq/boot_schema.go
@@ -1,0 +1,145 @@
+package dnsmasq
+
+import (
+	"context"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/dnsmasq"
+	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+type bootResourceModel struct {
+	Interface     types.String `tfsdk:"interface"`
+	Tag           types.Set    `tfsdk:"tag"`
+	Filename      types.String `tfsdk:"filename"`
+	Servername    types.String `tfsdk:"servername"`
+	ServerAddress types.String `tfsdk:"server_address"`
+	Description   types.String `tfsdk:"description"`
+
+	Id types.String `tfsdk:"id"`
+}
+
+func bootResourceSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "Manages an OPNsense Dnsmasq DHCP boot entry.",
+
+		Attributes: map[string]schema.Attribute{
+			"interface": schema.StringAttribute{
+				MarkdownDescription: "The interface for this boot entry.",
+				Optional:            true,
+			},
+			"tag": schema.SetAttribute{
+				MarkdownDescription: "Tags associated with this boot entry. Defaults to `[]`.",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"filename": schema.StringAttribute{
+				MarkdownDescription: "The boot filename.",
+				Optional:            true,
+			},
+			"servername": schema.StringAttribute{
+				MarkdownDescription: "The boot server name.",
+				Optional:            true,
+			},
+			"server_address": schema.StringAttribute{
+				MarkdownDescription: "The boot server address.",
+				Optional:            true,
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Description for this boot entry.",
+				Optional:            true,
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "UUID of the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func bootDataSourceSchema() dschema.Schema {
+	return dschema.Schema{
+		MarkdownDescription: "Reads an OPNsense Dnsmasq DHCP boot entry.",
+
+		Attributes: map[string]dschema.Attribute{
+			"id": dschema.StringAttribute{
+				MarkdownDescription: "UUID of the resource.",
+				Required:            true,
+			},
+			"interface": dschema.StringAttribute{
+				MarkdownDescription: "The interface for this boot entry.",
+				Computed:            true,
+			},
+			"tag": dschema.SetAttribute{
+				MarkdownDescription: "Tags associated with this boot entry.",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+			"filename": dschema.StringAttribute{
+				MarkdownDescription: "The boot filename.",
+				Computed:            true,
+			},
+			"servername": dschema.StringAttribute{
+				MarkdownDescription: "The boot server name.",
+				Computed:            true,
+			},
+			"server_address": dschema.StringAttribute{
+				MarkdownDescription: "The boot server address.",
+				Computed:            true,
+			},
+			"description": dschema.StringAttribute{
+				MarkdownDescription: "Description for this boot entry.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func convertBootSchemaToStruct(d *bootResourceModel) (*dnsmasq.Boot, error) {
+	var tagList []string
+	d.Tag.ElementsAs(context.Background(), &tagList, false)
+
+	return &dnsmasq.Boot{
+		Interface:     api.SelectedMap(d.Interface.ValueString()),
+		Tag:           tagList,
+		Filename:      d.Filename.ValueString(),
+		Servername:    d.Servername.ValueString(),
+		ServerAddress: d.ServerAddress.ValueString(),
+		Description:   d.Description.ValueString(),
+	}, nil
+}
+
+func convertBootStructToSchema(d *dnsmasq.Boot) (*bootResourceModel, error) {
+	model := &bootResourceModel{
+		Interface:     types.StringValue(d.Interface.String()),
+		Filename:      tools.StringOrNull(d.Filename),
+		Servername:    tools.StringOrNull(d.Servername),
+		ServerAddress: tools.StringOrNull(d.ServerAddress),
+		Description:   tools.StringOrNull(d.Description),
+	}
+
+	var tagList []attr.Value
+	for _, i := range d.Tag {
+		if i == "" {
+			continue
+		}
+		tagList = append(tagList, basetypes.NewStringValue(i))
+	}
+	tagTypeList, _ := types.SetValue(types.StringType, tagList)
+	model.Tag = tagTypeList
+
+	return model, nil
+}

--- a/internal/service/dnsmasq/domain_data_source.go
+++ b/internal/service/dnsmasq/domain_data_source.go
@@ -1,0 +1,62 @@
+package dnsmasq
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+var _ datasource.DataSource = &domainDataSource{}
+var _ datasource.DataSourceWithConfigure = &domainDataSource{}
+
+func newDomainDataSource() datasource.DataSource {
+	return &domainDataSource{}
+}
+
+type domainDataSource struct {
+	client opnsense.Client
+}
+
+func (d *domainDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dnsmasq_domain"
+}
+
+func (d *domainDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = domainDataSourceSchema()
+}
+
+func (d *domainDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData))
+		return
+	}
+	d.client = opnsense.NewClient(apiClient)
+}
+
+func (d *domainDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data *domainResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := d.client.Dnsmasq().GetDomain(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq domain, got error: %s", err))
+		return
+	}
+	resourceModel, err := convertDomainStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq domain, got error: %s", err))
+		return
+	}
+	resourceModel.Id = data.Id
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}

--- a/internal/service/dnsmasq/domain_resource.go
+++ b/internal/service/dnsmasq/domain_resource.go
@@ -1,0 +1,135 @@
+package dnsmasq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &domainResource{}
+var _ resource.ResourceWithConfigure = &domainResource{}
+var _ resource.ResourceWithImportState = &domainResource{}
+
+func newDomainResource() resource.Resource {
+	return &domainResource{}
+}
+
+type domainResource struct {
+	client opnsense.Client
+}
+
+func (r *domainResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dnsmasq_domain"
+}
+
+func (r *domainResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = domainResourceSchema()
+}
+
+func (r *domainResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData))
+		return
+	}
+	r.client = opnsense.NewClient(apiClient)
+}
+
+func (r *domainResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *domainResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := convertDomainSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse dnsmasq domain, got error: %s", err))
+		return
+	}
+	id, err := r.client.Dnsmasq().AddDomain(ctx, resourceStruct)
+	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create dnsmasq domain, got error: %s", err))
+		return
+	}
+	data.Id = types.StringValue(id)
+	tflog.Trace(ctx, "created a resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *domainResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *domainResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := r.client.Dnsmasq().GetDomain(ctx, data.Id.ValueString())
+	if err != nil {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
+			tflog.Warn(ctx, "dnsmasq domain not present in remote, removing from state")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq domain, got error: %s", err))
+		return
+	}
+	resourceModel, err := convertDomainStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq domain, got error: %s", err))
+		return
+	}
+	resourceModel.Id = data.Id
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}
+
+func (r *domainResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *domainResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := convertDomainSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse dnsmasq domain, got error: %s", err))
+		return
+	}
+	err = r.client.Dnsmasq().UpdateDomain(ctx, data.Id.ValueString(), resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update dnsmasq domain, got error: %s", err))
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *domainResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *domainResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	err := r.client.Dnsmasq().DeleteDomain(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete dnsmasq domain, got error: %s", err))
+		return
+	}
+}
+
+func (r *domainResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/service/dnsmasq/domain_resource_test.go
+++ b/internal/service/dnsmasq/domain_resource_test.go
@@ -1,0 +1,49 @@
+package dnsmasq_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/browningluke/terraform-provider-opnsense/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDnsmasqDomainResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsmasqDomainResourceConfig("example.com", "8.8.8.8", "Test domain override"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_domain.test", "domain", "example.com"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_domain.test", "ip", "8.8.8.8"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_domain.test", "description", "Test domain override"),
+					resource.TestCheckResourceAttrSet("opnsense_dnsmasq_domain.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "opnsense_dnsmasq_domain.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDnsmasqDomainResourceConfig("example.com", "8.8.4.4", "Updated domain override"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_domain.test", "ip", "8.8.4.4"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_domain.test", "description", "Updated domain override"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDnsmasqDomainResourceConfig(domain, ip, description string) string {
+	return fmt.Sprintf(`
+resource "opnsense_dnsmasq_domain" "test" {
+  domain      = %[1]q
+  ip          = %[2]q
+  description = %[3]q
+}
+`, domain, ip, description)
+}

--- a/internal/service/dnsmasq/domain_schema.go
+++ b/internal/service/dnsmasq/domain_schema.go
@@ -1,0 +1,133 @@
+package dnsmasq
+
+import (
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/dnsmasq"
+	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type domainResourceModel struct {
+	Sequence      types.String `tfsdk:"sequence"`
+	Domain        types.String `tfsdk:"domain"`
+	FirewallAlias types.String `tfsdk:"firewall_alias"`
+	SourceIp      types.String `tfsdk:"source_ip"`
+	Port          types.String `tfsdk:"port"`
+	Ip            types.String `tfsdk:"ip"`
+	Description   types.String `tfsdk:"description"`
+
+	Id types.String `tfsdk:"id"`
+}
+
+func domainResourceSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "Manages an OPNsense Dnsmasq domain override.",
+
+		Attributes: map[string]schema.Attribute{
+			"sequence": schema.StringAttribute{
+				MarkdownDescription: "The sequence number.",
+				Optional:            true,
+			},
+			"domain": schema.StringAttribute{
+				MarkdownDescription: "The domain name.",
+				Optional:            true,
+			},
+			"firewall_alias": schema.StringAttribute{
+				MarkdownDescription: "The firewall alias (ipset).",
+				Optional:            true,
+			},
+			"source_ip": schema.StringAttribute{
+				MarkdownDescription: "The source IP.",
+				Optional:            true,
+			},
+			"port": schema.StringAttribute{
+				MarkdownDescription: "The port.",
+				Optional:            true,
+			},
+			"ip": schema.StringAttribute{
+				MarkdownDescription: "The IP address.",
+				Optional:            true,
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Description for this domain override.",
+				Optional:            true,
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "UUID of the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func domainDataSourceSchema() dschema.Schema {
+	return dschema.Schema{
+		MarkdownDescription: "Reads an OPNsense Dnsmasq domain override.",
+
+		Attributes: map[string]dschema.Attribute{
+			"id": dschema.StringAttribute{
+				MarkdownDescription: "UUID of the resource.",
+				Required:            true,
+			},
+			"sequence": dschema.StringAttribute{
+				MarkdownDescription: "The sequence number.",
+				Computed:            true,
+			},
+			"domain": dschema.StringAttribute{
+				MarkdownDescription: "The domain name.",
+				Computed:            true,
+			},
+			"firewall_alias": dschema.StringAttribute{
+				MarkdownDescription: "The firewall alias (ipset).",
+				Computed:            true,
+			},
+			"source_ip": dschema.StringAttribute{
+				MarkdownDescription: "The source IP.",
+				Computed:            true,
+			},
+			"port": dschema.StringAttribute{
+				MarkdownDescription: "The port.",
+				Computed:            true,
+			},
+			"ip": dschema.StringAttribute{
+				MarkdownDescription: "The IP address.",
+				Computed:            true,
+			},
+			"description": dschema.StringAttribute{
+				MarkdownDescription: "Description for this domain override.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func convertDomainSchemaToStruct(d *domainResourceModel) (*dnsmasq.Domain, error) {
+	return &dnsmasq.Domain{
+		Sequence:      d.Sequence.ValueString(),
+		Domain:        d.Domain.ValueString(),
+		FirewallAlias: api.SelectedMap(d.FirewallAlias.ValueString()),
+		SourceIp:      d.SourceIp.ValueString(),
+		Port:          d.Port.ValueString(),
+		Ip:            d.Ip.ValueString(),
+		Description:   d.Description.ValueString(),
+	}, nil
+}
+
+func convertDomainStructToSchema(d *dnsmasq.Domain) (*domainResourceModel, error) {
+	return &domainResourceModel{
+		Sequence:      tools.StringOrNull(d.Sequence),
+		Domain:        tools.StringOrNull(d.Domain),
+		FirewallAlias: tools.StringOrNull(d.FirewallAlias.String()),
+		SourceIp:      tools.StringOrNull(d.SourceIp),
+		Port:          tools.StringOrNull(d.Port),
+		Ip:            tools.StringOrNull(d.Ip),
+		Description:   tools.StringOrNull(d.Description),
+	}, nil
+}

--- a/internal/service/dnsmasq/exports.go
+++ b/internal/service/dnsmasq/exports.go
@@ -1,23 +1,30 @@
-package interfaces
+package dnsmasq
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 func Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		newAssignResource,
-		newVipResource,
-		newVlanResource,
+		newBootResource,
+		newDomainResource,
+		newHostResource,
+		newOptionResource,
+		newRangeResource,
+		newTagResource,
 	}
 }
 
 func DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
-		newAssignDataSource,
-		newVipDataSource,
-		newVlanDataSource,
+		newBootDataSource,
+		newDomainDataSource,
+		newHostDataSource,
+		newOptionDataSource,
+		newRangeDataSource,
+		newTagDataSource,
 	}
 }

--- a/internal/service/dnsmasq/host_data_source.go
+++ b/internal/service/dnsmasq/host_data_source.go
@@ -1,0 +1,62 @@
+package dnsmasq
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+var _ datasource.DataSource = &hostDataSource{}
+var _ datasource.DataSourceWithConfigure = &hostDataSource{}
+
+func newHostDataSource() datasource.DataSource {
+	return &hostDataSource{}
+}
+
+type hostDataSource struct {
+	client opnsense.Client
+}
+
+func (d *hostDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dnsmasq_host"
+}
+
+func (d *hostDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = hostDataSourceSchema()
+}
+
+func (d *hostDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData))
+		return
+	}
+	d.client = opnsense.NewClient(apiClient)
+}
+
+func (d *hostDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data *hostResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := d.client.Dnsmasq().GetHost(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq host, got error: %s", err))
+		return
+	}
+	resourceModel, err := convertHostStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq host, got error: %s", err))
+		return
+	}
+	resourceModel.Id = data.Id
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}

--- a/internal/service/dnsmasq/host_resource.go
+++ b/internal/service/dnsmasq/host_resource.go
@@ -1,0 +1,135 @@
+package dnsmasq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &hostResource{}
+var _ resource.ResourceWithConfigure = &hostResource{}
+var _ resource.ResourceWithImportState = &hostResource{}
+
+func newHostResource() resource.Resource {
+	return &hostResource{}
+}
+
+type hostResource struct {
+	client opnsense.Client
+}
+
+func (r *hostResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dnsmasq_host"
+}
+
+func (r *hostResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = hostResourceSchema()
+}
+
+func (r *hostResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData))
+		return
+	}
+	r.client = opnsense.NewClient(apiClient)
+}
+
+func (r *hostResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *hostResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := convertHostSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse dnsmasq host, got error: %s", err))
+		return
+	}
+	id, err := r.client.Dnsmasq().AddHost(ctx, resourceStruct)
+	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create dnsmasq host, got error: %s", err))
+		return
+	}
+	data.Id = types.StringValue(id)
+	tflog.Trace(ctx, "created a resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *hostResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *hostResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := r.client.Dnsmasq().GetHost(ctx, data.Id.ValueString())
+	if err != nil {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
+			tflog.Warn(ctx, "dnsmasq host not present in remote, removing from state")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq host, got error: %s", err))
+		return
+	}
+	resourceModel, err := convertHostStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq host, got error: %s", err))
+		return
+	}
+	resourceModel.Id = data.Id
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}
+
+func (r *hostResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *hostResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := convertHostSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse dnsmasq host, got error: %s", err))
+		return
+	}
+	err = r.client.Dnsmasq().UpdateHost(ctx, data.Id.ValueString(), resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update dnsmasq host, got error: %s", err))
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *hostResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *hostResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	err := r.client.Dnsmasq().DeleteHost(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete dnsmasq host, got error: %s", err))
+		return
+	}
+}
+
+func (r *hostResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/service/dnsmasq/host_resource_test.go
+++ b/internal/service/dnsmasq/host_resource_test.go
@@ -1,0 +1,48 @@
+package dnsmasq_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/browningluke/terraform-provider-opnsense/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDnsmasqHostResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsmasqHostResourceConfig("testhost", "example.com", "Test host"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_host.test", "hostname", "testhost"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_host.test", "domain", "example.com"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_host.test", "description", "Test host"),
+					resource.TestCheckResourceAttrSet("opnsense_dnsmasq_host.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "opnsense_dnsmasq_host.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDnsmasqHostResourceConfig("testhost", "example.com", "Updated host description"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_host.test", "description", "Updated host description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDnsmasqHostResourceConfig(hostname, domain, description string) string {
+	return fmt.Sprintf(`
+resource "opnsense_dnsmasq_host" "test" {
+  hostname    = %[1]q
+  domain      = %[2]q
+  description = %[3]q
+}
+`, hostname, domain, description)
+}

--- a/internal/service/dnsmasq/host_schema.go
+++ b/internal/service/dnsmasq/host_schema.go
@@ -1,0 +1,268 @@
+package dnsmasq
+
+import (
+	"context"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/dnsmasq"
+	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+type hostResourceModel struct {
+	Hostname          types.String `tfsdk:"hostname"`
+	Domain            types.String `tfsdk:"domain"`
+	IsLocalDomain     types.Bool   `tfsdk:"is_local_domain"`
+	IpAddresses       types.Set    `tfsdk:"ip_addresses"`
+	AliasRecords      types.Set    `tfsdk:"alias_records"`
+	CnameRecords      types.Set    `tfsdk:"cname_records"`
+	ClientId          types.String `tfsdk:"client_id"`
+	HardwareAddresses types.Set    `tfsdk:"hardware_addresses"`
+	Tag               types.String `tfsdk:"tag"`
+	IsIgnored         types.Bool   `tfsdk:"is_ignored"`
+	Description       types.String `tfsdk:"description"`
+	Comments          types.String `tfsdk:"comments"`
+
+	Id types.String `tfsdk:"id"`
+}
+
+func hostResourceSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "Manages an OPNsense Dnsmasq host entry.",
+
+		Attributes: map[string]schema.Attribute{
+			"hostname": schema.StringAttribute{
+				MarkdownDescription: "The hostname.",
+				Optional:            true,
+			},
+			"domain": schema.StringAttribute{
+				MarkdownDescription: "The domain.",
+				Optional:            true,
+			},
+			"is_local_domain": schema.BoolAttribute{
+				MarkdownDescription: "Whether this is a local domain. Defaults to `false`.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
+			"ip_addresses": schema.SetAttribute{
+				MarkdownDescription: "Set of IP addresses. Defaults to `[]`.",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"alias_records": schema.SetAttribute{
+				MarkdownDescription: "Set of alias records. Defaults to `[]`.",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"cname_records": schema.SetAttribute{
+				MarkdownDescription: "Set of CNAME records. Defaults to `[]`.",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"client_id": schema.StringAttribute{
+				MarkdownDescription: "The client ID.",
+				Optional:            true,
+			},
+			"hardware_addresses": schema.SetAttribute{
+				MarkdownDescription: "Set of hardware (MAC) addresses. Defaults to `[]`.",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"tag": schema.StringAttribute{
+				MarkdownDescription: "The tag for this host.",
+				Optional:            true,
+			},
+			"is_ignored": schema.BoolAttribute{
+				MarkdownDescription: "Whether this host is ignored. Defaults to `false`.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Description for this host entry.",
+				Optional:            true,
+			},
+			"comments": schema.StringAttribute{
+				MarkdownDescription: "Comments for this host entry.",
+				Optional:            true,
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "UUID of the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func hostDataSourceSchema() dschema.Schema {
+	return dschema.Schema{
+		MarkdownDescription: "Reads an OPNsense Dnsmasq host entry.",
+
+		Attributes: map[string]dschema.Attribute{
+			"id": dschema.StringAttribute{
+				MarkdownDescription: "UUID of the resource.",
+				Required:            true,
+			},
+			"hostname": dschema.StringAttribute{
+				MarkdownDescription: "The hostname.",
+				Computed:            true,
+			},
+			"domain": dschema.StringAttribute{
+				MarkdownDescription: "The domain.",
+				Computed:            true,
+			},
+			"is_local_domain": dschema.BoolAttribute{
+				MarkdownDescription: "Whether this is a local domain.",
+				Computed:            true,
+			},
+			"ip_addresses": dschema.SetAttribute{
+				MarkdownDescription: "Set of IP addresses.",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+			"alias_records": dschema.SetAttribute{
+				MarkdownDescription: "Set of alias records.",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+			"cname_records": dschema.SetAttribute{
+				MarkdownDescription: "Set of CNAME records.",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+			"client_id": dschema.StringAttribute{
+				MarkdownDescription: "The client ID.",
+				Computed:            true,
+			},
+			"hardware_addresses": dschema.SetAttribute{
+				MarkdownDescription: "Set of hardware (MAC) addresses.",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+			"tag": dschema.StringAttribute{
+				MarkdownDescription: "The tag for this host.",
+				Computed:            true,
+			},
+			"is_ignored": dschema.BoolAttribute{
+				MarkdownDescription: "Whether this host is ignored.",
+				Computed:            true,
+			},
+			"description": dschema.StringAttribute{
+				MarkdownDescription: "Description for this host entry.",
+				Computed:            true,
+			},
+			"comments": dschema.StringAttribute{
+				MarkdownDescription: "Comments for this host entry.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func convertHostSchemaToStruct(d *hostResourceModel) (*dnsmasq.Host, error) {
+	var ipAddressesList []string
+	d.IpAddresses.ElementsAs(context.Background(), &ipAddressesList, false)
+
+	var aliasRecordsList []string
+	d.AliasRecords.ElementsAs(context.Background(), &aliasRecordsList, false)
+
+	var cnameRecordsList []string
+	d.CnameRecords.ElementsAs(context.Background(), &cnameRecordsList, false)
+
+	var hardwareAddressesList []string
+	d.HardwareAddresses.ElementsAs(context.Background(), &hardwareAddressesList, false)
+
+	return &dnsmasq.Host{
+		Hostname:          d.Hostname.ValueString(),
+		Domain:            d.Domain.ValueString(),
+		IsLocalDomain:     tools.BoolToString(d.IsLocalDomain.ValueBool()),
+		IpAddresses:       ipAddressesList,
+		AliasRecords:      aliasRecordsList,
+		CnameRecords:      cnameRecordsList,
+		ClientId:          d.ClientId.ValueString(),
+		HardwareAddresses: hardwareAddressesList,
+		Tag:               api.SelectedMap(d.Tag.ValueString()),
+		IsIgnored:         tools.BoolToString(d.IsIgnored.ValueBool()),
+		Description:       d.Description.ValueString(),
+		Comments:          d.Comments.ValueString(),
+	}, nil
+}
+
+func convertHostStructToSchema(d *dnsmasq.Host) (*hostResourceModel, error) {
+	model := &hostResourceModel{
+		Hostname:      tools.StringOrNull(d.Hostname),
+		Domain:        tools.StringOrNull(d.Domain),
+		IsLocalDomain: types.BoolValue(tools.StringToBool(d.IsLocalDomain)),
+		ClientId:      tools.StringOrNull(d.ClientId),
+		Tag:           tools.StringOrNull(d.Tag.String()),
+		IsIgnored:     types.BoolValue(tools.StringToBool(d.IsIgnored)),
+		Description:   tools.StringOrNull(d.Description),
+		Comments:      tools.StringOrNull(d.Comments),
+	}
+
+	// Parse 'IpAddresses'
+	var ipAddressesList []attr.Value
+	for _, i := range d.IpAddresses {
+		if i == "" {
+			continue
+		}
+		ipAddressesList = append(ipAddressesList, basetypes.NewStringValue(i))
+	}
+	ipAddressesTypeList, _ := types.SetValue(types.StringType, ipAddressesList)
+	model.IpAddresses = ipAddressesTypeList
+
+	// Parse 'AliasRecords'
+	var aliasRecordsList []attr.Value
+	for _, i := range d.AliasRecords {
+		if i == "" {
+			continue
+		}
+		aliasRecordsList = append(aliasRecordsList, basetypes.NewStringValue(i))
+	}
+	aliasRecordsTypeList, _ := types.SetValue(types.StringType, aliasRecordsList)
+	model.AliasRecords = aliasRecordsTypeList
+
+	// Parse 'CnameRecords'
+	var cnameRecordsList []attr.Value
+	for _, i := range d.CnameRecords {
+		if i == "" {
+			continue
+		}
+		cnameRecordsList = append(cnameRecordsList, basetypes.NewStringValue(i))
+	}
+	cnameRecordsTypeList, _ := types.SetValue(types.StringType, cnameRecordsList)
+	model.CnameRecords = cnameRecordsTypeList
+
+	// Parse 'HardwareAddresses'
+	var hardwareAddressesList []attr.Value
+	for _, i := range d.HardwareAddresses {
+		if i == "" {
+			continue
+		}
+		hardwareAddressesList = append(hardwareAddressesList, basetypes.NewStringValue(i))
+	}
+	hardwareAddressesTypeList, _ := types.SetValue(types.StringType, hardwareAddressesList)
+	model.HardwareAddresses = hardwareAddressesTypeList
+
+	return model, nil
+}

--- a/internal/service/dnsmasq/option_data_source.go
+++ b/internal/service/dnsmasq/option_data_source.go
@@ -1,0 +1,62 @@
+package dnsmasq
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+var _ datasource.DataSource = &optionDataSource{}
+var _ datasource.DataSourceWithConfigure = &optionDataSource{}
+
+func newOptionDataSource() datasource.DataSource {
+	return &optionDataSource{}
+}
+
+type optionDataSource struct {
+	client opnsense.Client
+}
+
+func (d *optionDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dnsmasq_option"
+}
+
+func (d *optionDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = optionDataSourceSchema()
+}
+
+func (d *optionDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData))
+		return
+	}
+	d.client = opnsense.NewClient(apiClient)
+}
+
+func (d *optionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data *optionResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := d.client.Dnsmasq().GetOption(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq option, got error: %s", err))
+		return
+	}
+	resourceModel, err := convertOptionStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq option, got error: %s", err))
+		return
+	}
+	resourceModel.Id = data.Id
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}

--- a/internal/service/dnsmasq/option_resource.go
+++ b/internal/service/dnsmasq/option_resource.go
@@ -1,0 +1,135 @@
+package dnsmasq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &optionResource{}
+var _ resource.ResourceWithConfigure = &optionResource{}
+var _ resource.ResourceWithImportState = &optionResource{}
+
+func newOptionResource() resource.Resource {
+	return &optionResource{}
+}
+
+type optionResource struct {
+	client opnsense.Client
+}
+
+func (r *optionResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dnsmasq_option"
+}
+
+func (r *optionResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = optionResourceSchema()
+}
+
+func (r *optionResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData))
+		return
+	}
+	r.client = opnsense.NewClient(apiClient)
+}
+
+func (r *optionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *optionResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := convertOptionSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse dnsmasq option, got error: %s", err))
+		return
+	}
+	id, err := r.client.Dnsmasq().AddOption(ctx, resourceStruct)
+	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create dnsmasq option, got error: %s", err))
+		return
+	}
+	data.Id = types.StringValue(id)
+	tflog.Trace(ctx, "created a resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *optionResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *optionResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := r.client.Dnsmasq().GetOption(ctx, data.Id.ValueString())
+	if err != nil {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
+			tflog.Warn(ctx, "dnsmasq option not present in remote, removing from state")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq option, got error: %s", err))
+		return
+	}
+	resourceModel, err := convertOptionStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq option, got error: %s", err))
+		return
+	}
+	resourceModel.Id = data.Id
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}
+
+func (r *optionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *optionResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := convertOptionSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse dnsmasq option, got error: %s", err))
+		return
+	}
+	err = r.client.Dnsmasq().UpdateOption(ctx, data.Id.ValueString(), resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update dnsmasq option, got error: %s", err))
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *optionResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *optionResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	err := r.client.Dnsmasq().DeleteOption(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete dnsmasq option, got error: %s", err))
+		return
+	}
+}
+
+func (r *optionResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/service/dnsmasq/option_resource_test.go
+++ b/internal/service/dnsmasq/option_resource_test.go
@@ -1,0 +1,47 @@
+package dnsmasq_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/browningluke/terraform-provider-opnsense/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDnsmasqOptionResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsmasqOptionResourceConfig("192.168.1.1,192.168.1.2", "Test DNS option"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_option.test", "value", "192.168.1.1,192.168.1.2"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_option.test", "description", "Test DNS option"),
+					resource.TestCheckResourceAttrSet("opnsense_dnsmasq_option.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "opnsense_dnsmasq_option.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDnsmasqOptionResourceConfig("10.0.0.1", "Updated DNS option"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_option.test", "value", "10.0.0.1"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_option.test", "description", "Updated DNS option"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDnsmasqOptionResourceConfig(value, description string) string {
+	return fmt.Sprintf(`
+resource "opnsense_dnsmasq_option" "test" {
+  value       = %[1]q
+  description = %[2]q
+}
+`, value, description)
+}

--- a/internal/service/dnsmasq/option_schema.go
+++ b/internal/service/dnsmasq/option_schema.go
@@ -1,0 +1,178 @@
+package dnsmasq
+
+import (
+	"context"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/dnsmasq"
+	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+type optionResourceModel struct {
+	Type         types.String `tfsdk:"type"`
+	OptionV4     types.String `tfsdk:"option_v4"`
+	OptionV6     types.String `tfsdk:"option_v6"`
+	Interface    types.String `tfsdk:"interface"`
+	TypeSetTags  types.Set    `tfsdk:"type_set_tags"`
+	TypeMatchTag types.String `tfsdk:"type_match_tag"`
+	Value        types.String `tfsdk:"value"`
+	Force        types.String `tfsdk:"force"`
+	Description  types.String `tfsdk:"description"`
+
+	Id types.String `tfsdk:"id"`
+}
+
+func optionResourceSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "Manages an OPNsense Dnsmasq DHCP option.",
+
+		Attributes: map[string]schema.Attribute{
+			"type": schema.StringAttribute{
+				MarkdownDescription: "The option type.",
+				Optional:            true,
+			},
+			"option_v4": schema.StringAttribute{
+				MarkdownDescription: "The IPv4 DHCP option.",
+				Optional:            true,
+			},
+			"option_v6": schema.StringAttribute{
+				MarkdownDescription: "The IPv6 DHCP option.",
+				Optional:            true,
+			},
+			"interface": schema.StringAttribute{
+				MarkdownDescription: "The interface.",
+				Optional:            true,
+			},
+			"type_set_tags": schema.SetAttribute{
+				MarkdownDescription: "Tags to set. Defaults to `[]`.",
+				Optional:            true,
+				Computed:            true,
+				ElementType:         types.StringType,
+				Default:             setdefault.StaticValue(tools.EmptySetValue(types.StringType)),
+			},
+			"type_match_tag": schema.StringAttribute{
+				MarkdownDescription: "Tag to match.",
+				Optional:            true,
+			},
+			"value": schema.StringAttribute{
+				MarkdownDescription: "The option value.",
+				Optional:            true,
+			},
+			"force": schema.StringAttribute{
+				MarkdownDescription: "Force this option.",
+				Optional:            true,
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Description for this option.",
+				Optional:            true,
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "UUID of the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func optionDataSourceSchema() dschema.Schema {
+	return dschema.Schema{
+		MarkdownDescription: "Reads an OPNsense Dnsmasq DHCP option.",
+
+		Attributes: map[string]dschema.Attribute{
+			"id": dschema.StringAttribute{
+				MarkdownDescription: "UUID of the resource.",
+				Required:            true,
+			},
+			"type": dschema.StringAttribute{
+				MarkdownDescription: "The option type.",
+				Computed:            true,
+			},
+			"option_v4": dschema.StringAttribute{
+				MarkdownDescription: "The IPv4 DHCP option.",
+				Computed:            true,
+			},
+			"option_v6": dschema.StringAttribute{
+				MarkdownDescription: "The IPv6 DHCP option.",
+				Computed:            true,
+			},
+			"interface": dschema.StringAttribute{
+				MarkdownDescription: "The interface.",
+				Computed:            true,
+			},
+			"type_set_tags": dschema.SetAttribute{
+				MarkdownDescription: "Tags to set.",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
+			"type_match_tag": dschema.StringAttribute{
+				MarkdownDescription: "Tag to match.",
+				Computed:            true,
+			},
+			"value": dschema.StringAttribute{
+				MarkdownDescription: "The option value.",
+				Computed:            true,
+			},
+			"force": dschema.StringAttribute{
+				MarkdownDescription: "Force this option.",
+				Computed:            true,
+			},
+			"description": dschema.StringAttribute{
+				MarkdownDescription: "Description for this option.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func convertOptionSchemaToStruct(d *optionResourceModel) (*dnsmasq.Option, error) {
+	var typeSetTagsList []string
+	d.TypeSetTags.ElementsAs(context.Background(), &typeSetTagsList, false)
+
+	return &dnsmasq.Option{
+		Type:         api.SelectedMap(d.Type.ValueString()),
+		OptionV4:     api.SelectedMap(d.OptionV4.ValueString()),
+		OptionV6:     api.SelectedMap(d.OptionV6.ValueString()),
+		Interface:    api.SelectedMap(d.Interface.ValueString()),
+		TypeSetTags:  typeSetTagsList,
+		TypeMatchTag: api.SelectedMap(d.TypeMatchTag.ValueString()),
+		Value:        d.Value.ValueString(),
+		Force:        d.Force.ValueString(),
+		Description:  d.Description.ValueString(),
+	}, nil
+}
+
+func convertOptionStructToSchema(d *dnsmasq.Option) (*optionResourceModel, error) {
+	model := &optionResourceModel{
+		Type:         tools.StringOrNull(d.Type.String()),
+		OptionV4:     tools.StringOrNull(d.OptionV4.String()),
+		OptionV6:     tools.StringOrNull(d.OptionV6.String()),
+		Interface:    tools.StringOrNull(d.Interface.String()),
+		TypeMatchTag: tools.StringOrNull(d.TypeMatchTag.String()),
+		Value:        tools.StringOrNull(d.Value),
+		Force:        tools.StringOrNull(d.Force),
+		Description:  tools.StringOrNull(d.Description),
+	}
+
+	var typeSetTagsList []attr.Value
+	for _, i := range d.TypeSetTags {
+		if i == "" {
+			continue
+		}
+		typeSetTagsList = append(typeSetTagsList, basetypes.NewStringValue(i))
+	}
+	typeSetTagsTypeList, _ := types.SetValue(types.StringType, typeSetTagsList)
+	model.TypeSetTags = typeSetTagsTypeList
+
+	return model, nil
+}

--- a/internal/service/dnsmasq/range_data_source.go
+++ b/internal/service/dnsmasq/range_data_source.go
@@ -1,0 +1,62 @@
+package dnsmasq
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+var _ datasource.DataSource = &rangeDataSource{}
+var _ datasource.DataSourceWithConfigure = &rangeDataSource{}
+
+func newRangeDataSource() datasource.DataSource {
+	return &rangeDataSource{}
+}
+
+type rangeDataSource struct {
+	client opnsense.Client
+}
+
+func (d *rangeDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dnsmasq_range"
+}
+
+func (d *rangeDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = rangeDataSourceSchema()
+}
+
+func (d *rangeDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData))
+		return
+	}
+	d.client = opnsense.NewClient(apiClient)
+}
+
+func (d *rangeDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data *rangeResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := d.client.Dnsmasq().GetRange(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq range, got error: %s", err))
+		return
+	}
+	resourceModel, err := convertRangeStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq range, got error: %s", err))
+		return
+	}
+	resourceModel.Id = data.Id
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}

--- a/internal/service/dnsmasq/range_resource.go
+++ b/internal/service/dnsmasq/range_resource.go
@@ -1,0 +1,135 @@
+package dnsmasq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &rangeResource{}
+var _ resource.ResourceWithConfigure = &rangeResource{}
+var _ resource.ResourceWithImportState = &rangeResource{}
+
+func newRangeResource() resource.Resource {
+	return &rangeResource{}
+}
+
+type rangeResource struct {
+	client opnsense.Client
+}
+
+func (r *rangeResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dnsmasq_range"
+}
+
+func (r *rangeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = rangeResourceSchema()
+}
+
+func (r *rangeResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData))
+		return
+	}
+	r.client = opnsense.NewClient(apiClient)
+}
+
+func (r *rangeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *rangeResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := convertRangeSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse dnsmasq range, got error: %s", err))
+		return
+	}
+	id, err := r.client.Dnsmasq().AddRange(ctx, resourceStruct)
+	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create dnsmasq range, got error: %s", err))
+		return
+	}
+	data.Id = types.StringValue(id)
+	tflog.Trace(ctx, "created a resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *rangeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *rangeResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := r.client.Dnsmasq().GetRange(ctx, data.Id.ValueString())
+	if err != nil {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
+			tflog.Warn(ctx, "dnsmasq range not present in remote, removing from state")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq range, got error: %s", err))
+		return
+	}
+	resourceModel, err := convertRangeStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq range, got error: %s", err))
+		return
+	}
+	resourceModel.Id = data.Id
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}
+
+func (r *rangeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *rangeResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := convertRangeSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse dnsmasq range, got error: %s", err))
+		return
+	}
+	err = r.client.Dnsmasq().UpdateRange(ctx, data.Id.ValueString(), resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update dnsmasq range, got error: %s", err))
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *rangeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *rangeResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	err := r.client.Dnsmasq().DeleteRange(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete dnsmasq range, got error: %s", err))
+		return
+	}
+}
+
+func (r *rangeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/service/dnsmasq/range_resource_test.go
+++ b/internal/service/dnsmasq/range_resource_test.go
@@ -1,0 +1,52 @@
+package dnsmasq_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/browningluke/terraform-provider-opnsense/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDnsmasqRangeResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsmasqRangeResourceConfig("192.168.1.100", "192.168.1.200", "255.255.255.0", "Test DHCP range"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_range.test", "start_address", "192.168.1.100"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_range.test", "end_address", "192.168.1.200"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_range.test", "subnet_mask", "255.255.255.0"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_range.test", "description", "Test DHCP range"),
+					resource.TestCheckResourceAttrSet("opnsense_dnsmasq_range.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "opnsense_dnsmasq_range.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDnsmasqRangeResourceConfig("192.168.1.50", "192.168.1.150", "255.255.255.0", "Updated DHCP range"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_range.test", "start_address", "192.168.1.50"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_range.test", "end_address", "192.168.1.150"),
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_range.test", "description", "Updated DHCP range"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDnsmasqRangeResourceConfig(startAddr, endAddr, subnetMask, description string) string {
+	return fmt.Sprintf(`
+resource "opnsense_dnsmasq_range" "test" {
+  start_address = %[1]q
+  end_address   = %[2]q
+  subnet_mask   = %[3]q
+  description   = %[4]q
+}
+`, startAddr, endAddr, subnetMask, description)
+}

--- a/internal/service/dnsmasq/range_schema.go
+++ b/internal/service/dnsmasq/range_schema.go
@@ -1,0 +1,257 @@
+package dnsmasq
+
+import (
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/dnsmasq"
+	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type rangeResourceModel struct {
+	Interface        types.String `tfsdk:"interface"`
+	Tag              types.String `tfsdk:"tag"`
+	StartAddress     types.String `tfsdk:"start_address"`
+	EndAddress       types.String `tfsdk:"end_address"`
+	SubnetMask       types.String `tfsdk:"subnet_mask"`
+	Constructor      types.String `tfsdk:"constructor"`
+	Mode             types.String `tfsdk:"mode"`
+	PrefixLength     types.String `tfsdk:"prefix_length"`
+	LeaseTime        types.String `tfsdk:"lease_time"`
+	DomainType       types.String `tfsdk:"domain_type"`
+	Domain           types.String `tfsdk:"domain"`
+	DisableHASync    types.Bool   `tfsdk:"disable_ha_sync"`
+	RaMode           types.String `tfsdk:"ra_mode"`
+	RaPriority       types.String `tfsdk:"ra_priority"`
+	RaMTU            types.String `tfsdk:"ra_mtu"`
+	RaInterval       types.String `tfsdk:"ra_interval"`
+	RaRouterLifetime types.String `tfsdk:"ra_router_lifetime"`
+	Description      types.String `tfsdk:"description"`
+
+	Id types.String `tfsdk:"id"`
+}
+
+func rangeResourceSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "Manages an OPNsense Dnsmasq DHCP range.",
+
+		Attributes: map[string]schema.Attribute{
+			"interface": schema.StringAttribute{
+				MarkdownDescription: "The interface.",
+				Optional:            true,
+			},
+			"tag": schema.StringAttribute{
+				MarkdownDescription: "The tag.",
+				Optional:            true,
+			},
+			"start_address": schema.StringAttribute{
+				MarkdownDescription: "The start address of the range.",
+				Optional:            true,
+			},
+			"end_address": schema.StringAttribute{
+				MarkdownDescription: "The end address of the range.",
+				Optional:            true,
+			},
+			"subnet_mask": schema.StringAttribute{
+				MarkdownDescription: "The subnet mask.",
+				Optional:            true,
+			},
+			"constructor": schema.StringAttribute{
+				MarkdownDescription: "The constructor.",
+				Optional:            true,
+			},
+			"mode": schema.StringAttribute{
+				MarkdownDescription: "The mode.",
+				Optional:            true,
+			},
+			"prefix_length": schema.StringAttribute{
+				MarkdownDescription: "The prefix length.",
+				Optional:            true,
+			},
+			"lease_time": schema.StringAttribute{
+				MarkdownDescription: "The lease time.",
+				Optional:            true,
+			},
+			"domain_type": schema.StringAttribute{
+				MarkdownDescription: "The domain type.",
+				Optional:            true,
+			},
+			"domain": schema.StringAttribute{
+				MarkdownDescription: "The domain.",
+				Optional:            true,
+			},
+			"disable_ha_sync": schema.BoolAttribute{
+				MarkdownDescription: "Disable HA sync. Defaults to `false`.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
+			"ra_mode": schema.StringAttribute{
+				MarkdownDescription: "The RA mode.",
+				Optional:            true,
+			},
+			"ra_priority": schema.StringAttribute{
+				MarkdownDescription: "The RA priority.",
+				Optional:            true,
+			},
+			"ra_mtu": schema.StringAttribute{
+				MarkdownDescription: "The RA MTU.",
+				Optional:            true,
+			},
+			"ra_interval": schema.StringAttribute{
+				MarkdownDescription: "The RA interval.",
+				Optional:            true,
+			},
+			"ra_router_lifetime": schema.StringAttribute{
+				MarkdownDescription: "The RA router lifetime.",
+				Optional:            true,
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Description for this range.",
+				Optional:            true,
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "UUID of the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func rangeDataSourceSchema() dschema.Schema {
+	return dschema.Schema{
+		MarkdownDescription: "Reads an OPNsense Dnsmasq DHCP range.",
+
+		Attributes: map[string]dschema.Attribute{
+			"id": dschema.StringAttribute{
+				MarkdownDescription: "UUID of the resource.",
+				Required:            true,
+			},
+			"interface": dschema.StringAttribute{
+				MarkdownDescription: "The interface.",
+				Computed:            true,
+			},
+			"tag": dschema.StringAttribute{
+				MarkdownDescription: "The tag.",
+				Computed:            true,
+			},
+			"start_address": dschema.StringAttribute{
+				MarkdownDescription: "The start address of the range.",
+				Computed:            true,
+			},
+			"end_address": dschema.StringAttribute{
+				MarkdownDescription: "The end address of the range.",
+				Computed:            true,
+			},
+			"subnet_mask": dschema.StringAttribute{
+				MarkdownDescription: "The subnet mask.",
+				Computed:            true,
+			},
+			"constructor": dschema.StringAttribute{
+				MarkdownDescription: "The constructor.",
+				Computed:            true,
+			},
+			"mode": dschema.StringAttribute{
+				MarkdownDescription: "The mode.",
+				Computed:            true,
+			},
+			"prefix_length": dschema.StringAttribute{
+				MarkdownDescription: "The prefix length.",
+				Computed:            true,
+			},
+			"lease_time": dschema.StringAttribute{
+				MarkdownDescription: "The lease time.",
+				Computed:            true,
+			},
+			"domain_type": dschema.StringAttribute{
+				MarkdownDescription: "The domain type.",
+				Computed:            true,
+			},
+			"domain": dschema.StringAttribute{
+				MarkdownDescription: "The domain.",
+				Computed:            true,
+			},
+			"disable_ha_sync": dschema.BoolAttribute{
+				MarkdownDescription: "Whether HA sync is disabled.",
+				Computed:            true,
+			},
+			"ra_mode": dschema.StringAttribute{
+				MarkdownDescription: "The RA mode.",
+				Computed:            true,
+			},
+			"ra_priority": dschema.StringAttribute{
+				MarkdownDescription: "The RA priority.",
+				Computed:            true,
+			},
+			"ra_mtu": dschema.StringAttribute{
+				MarkdownDescription: "The RA MTU.",
+				Computed:            true,
+			},
+			"ra_interval": dschema.StringAttribute{
+				MarkdownDescription: "The RA interval.",
+				Computed:            true,
+			},
+			"ra_router_lifetime": dschema.StringAttribute{
+				MarkdownDescription: "The RA router lifetime.",
+				Computed:            true,
+			},
+			"description": dschema.StringAttribute{
+				MarkdownDescription: "Description for this range.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func convertRangeSchemaToStruct(d *rangeResourceModel) (*dnsmasq.Range, error) {
+	return &dnsmasq.Range{
+		Interface:        api.SelectedMap(d.Interface.ValueString()),
+		Tag:              api.SelectedMap(d.Tag.ValueString()),
+		StartAddress:     d.StartAddress.ValueString(),
+		EndAddress:       d.EndAddress.ValueString(),
+		SubnetMask:       d.SubnetMask.ValueString(),
+		Constructor:      api.SelectedMap(d.Constructor.ValueString()),
+		Mode:             api.SelectedMap(d.Mode.ValueString()),
+		PrefixLength:     d.PrefixLength.ValueString(),
+		LeaseTime:        d.LeaseTime.ValueString(),
+		DomainType:       api.SelectedMap(d.DomainType.ValueString()),
+		Domain:           d.Domain.ValueString(),
+		DisableHASync:    tools.BoolToString(d.DisableHASync.ValueBool()),
+		RaMode:           api.SelectedMap(d.RaMode.ValueString()),
+		RaPriority:       api.SelectedMap(d.RaPriority.ValueString()),
+		RaMTU:            d.RaMTU.ValueString(),
+		RaInterval:       d.RaInterval.ValueString(),
+		RaRouterLifetime: d.RaRouterLifetime.ValueString(),
+		Description:      d.Description.ValueString(),
+	}, nil
+}
+
+func convertRangeStructToSchema(d *dnsmasq.Range) (*rangeResourceModel, error) {
+	return &rangeResourceModel{
+		Interface:        tools.StringOrNull(d.Interface.String()),
+		Tag:              tools.StringOrNull(d.Tag.String()),
+		StartAddress:     tools.StringOrNull(d.StartAddress),
+		EndAddress:       tools.StringOrNull(d.EndAddress),
+		SubnetMask:       tools.StringOrNull(d.SubnetMask),
+		Constructor:      tools.StringOrNull(d.Constructor.String()),
+		Mode:             tools.StringOrNull(d.Mode.String()),
+		PrefixLength:     tools.StringOrNull(d.PrefixLength),
+		LeaseTime:        tools.StringOrNull(d.LeaseTime),
+		DomainType:       tools.StringOrNull(d.DomainType.String()),
+		Domain:           tools.StringOrNull(d.Domain),
+		DisableHASync:    types.BoolValue(tools.StringToBool(d.DisableHASync)),
+		RaMode:           tools.StringOrNull(d.RaMode.String()),
+		RaPriority:       tools.StringOrNull(d.RaPriority.String()),
+		RaMTU:            tools.StringOrNull(d.RaMTU),
+		RaInterval:       tools.StringOrNull(d.RaInterval),
+		RaRouterLifetime: tools.StringOrNull(d.RaRouterLifetime),
+		Description:      tools.StringOrNull(d.Description),
+	}, nil
+}

--- a/internal/service/dnsmasq/tag_data_source.go
+++ b/internal/service/dnsmasq/tag_data_source.go
@@ -1,0 +1,62 @@
+package dnsmasq
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+var _ datasource.DataSource = &tagDataSource{}
+var _ datasource.DataSourceWithConfigure = &tagDataSource{}
+
+func newTagDataSource() datasource.DataSource {
+	return &tagDataSource{}
+}
+
+type tagDataSource struct {
+	client opnsense.Client
+}
+
+func (d *tagDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dnsmasq_tag"
+}
+
+func (d *tagDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = tagDataSourceSchema()
+}
+
+func (d *tagDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData))
+		return
+	}
+	d.client = opnsense.NewClient(apiClient)
+}
+
+func (d *tagDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data *tagResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := d.client.Dnsmasq().GetTag(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq tag, got error: %s", err))
+		return
+	}
+	resourceModel, err := convertTagStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq tag, got error: %s", err))
+		return
+	}
+	resourceModel.Id = data.Id
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}

--- a/internal/service/dnsmasq/tag_resource.go
+++ b/internal/service/dnsmasq/tag_resource.go
@@ -1,0 +1,135 @@
+package dnsmasq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &tagResource{}
+var _ resource.ResourceWithConfigure = &tagResource{}
+var _ resource.ResourceWithImportState = &tagResource{}
+
+func newTagResource() resource.Resource {
+	return &tagResource{}
+}
+
+type tagResource struct {
+	client opnsense.Client
+}
+
+func (r *tagResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_dnsmasq_tag"
+}
+
+func (r *tagResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = tagResourceSchema()
+}
+
+func (r *tagResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData))
+		return
+	}
+	r.client = opnsense.NewClient(apiClient)
+}
+
+func (r *tagResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *tagResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := convertTagSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse dnsmasq tag, got error: %s", err))
+		return
+	}
+	id, err := r.client.Dnsmasq().AddTag(ctx, resourceStruct)
+	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create dnsmasq tag, got error: %s", err))
+		return
+	}
+	data.Id = types.StringValue(id)
+	tflog.Trace(ctx, "created a resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *tagResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *tagResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := r.client.Dnsmasq().GetTag(ctx, data.Id.ValueString())
+	if err != nil {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
+			tflog.Warn(ctx, "dnsmasq tag not present in remote, removing from state")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq tag, got error: %s", err))
+		return
+	}
+	resourceModel, err := convertTagStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read dnsmasq tag, got error: %s", err))
+		return
+	}
+	resourceModel.Id = data.Id
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}
+
+func (r *tagResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *tagResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := convertTagSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse dnsmasq tag, got error: %s", err))
+		return
+	}
+	err = r.client.Dnsmasq().UpdateTag(ctx, data.Id.ValueString(), resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update dnsmasq tag, got error: %s", err))
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *tagResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *tagResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	err := r.client.Dnsmasq().DeleteTag(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete dnsmasq tag, got error: %s", err))
+		return
+	}
+}
+
+func (r *tagResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/service/dnsmasq/tag_resource_test.go
+++ b/internal/service/dnsmasq/tag_resource_test.go
@@ -1,0 +1,44 @@
+package dnsmasq_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/browningluke/terraform-provider-opnsense/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccDnsmasqTagResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsmasqTagResourceConfig("test_tag"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_tag.test", "tag", "test_tag"),
+					resource.TestCheckResourceAttrSet("opnsense_dnsmasq_tag.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "opnsense_dnsmasq_tag.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDnsmasqTagResourceConfig("updated_tag"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_dnsmasq_tag.test", "tag", "updated_tag"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDnsmasqTagResourceConfig(tag string) string {
+	return fmt.Sprintf(`
+resource "opnsense_dnsmasq_tag" "test" {
+  tag = %[1]q
+}
+`, tag)
+}

--- a/internal/service/dnsmasq/tag_schema.go
+++ b/internal/service/dnsmasq/tag_schema.go
@@ -1,0 +1,65 @@
+package dnsmasq
+
+import (
+	"github.com/browningluke/opnsense-go/pkg/dnsmasq"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type tagResourceModel struct {
+	Tag types.String `tfsdk:"tag"`
+
+	Id types.String `tfsdk:"id"`
+}
+
+func tagResourceSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "Manages an OPNsense Dnsmasq tag.",
+
+		Attributes: map[string]schema.Attribute{
+			"tag": schema.StringAttribute{
+				MarkdownDescription: "The tag value.",
+				Required:            true,
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "UUID of the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func tagDataSourceSchema() dschema.Schema {
+	return dschema.Schema{
+		MarkdownDescription: "Reads an OPNsense Dnsmasq tag.",
+
+		Attributes: map[string]dschema.Attribute{
+			"id": dschema.StringAttribute{
+				MarkdownDescription: "UUID of the resource.",
+				Required:            true,
+			},
+			"tag": dschema.StringAttribute{
+				MarkdownDescription: "The tag value.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func convertTagSchemaToStruct(d *tagResourceModel) (*dnsmasq.Tag, error) {
+	return &dnsmasq.Tag{
+		Tag: d.Tag.ValueString(),
+	}, nil
+}
+
+func convertTagStructToSchema(d *dnsmasq.Tag) (*tagResourceModel, error) {
+	return &tagResourceModel{
+		Tag: types.StringValue(d.Tag),
+	}, nil
+}

--- a/internal/service/interfaces/assign_data_source.go
+++ b/internal/service/interfaces/assign_data_source.go
@@ -1,0 +1,62 @@
+package interfaces
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+var _ datasource.DataSource = &assignDataSource{}
+var _ datasource.DataSourceWithConfigure = &assignDataSource{}
+
+func newAssignDataSource() datasource.DataSource {
+	return &assignDataSource{}
+}
+
+type assignDataSource struct {
+	client opnsense.Client
+}
+
+func (d *assignDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_interfaces_assign"
+}
+
+func (d *assignDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = assignDataSourceSchema()
+}
+
+func (d *assignDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData))
+		return
+	}
+	d.client = opnsense.NewClient(apiClient)
+}
+
+func (d *assignDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data *assignResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := d.client.Interfaces().GetAssign(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read interfaces assign, got error: %s", err))
+		return
+	}
+	resourceModel, err := convertAssignStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read interfaces assign, got error: %s", err))
+		return
+	}
+	resourceModel.Id = data.Id
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}

--- a/internal/service/interfaces/assign_resource.go
+++ b/internal/service/interfaces/assign_resource.go
@@ -1,0 +1,135 @@
+package interfaces
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/browningluke/opnsense-go/pkg/api"
+	"github.com/browningluke/opnsense-go/pkg/errs"
+	"github.com/browningluke/opnsense-go/pkg/opnsense"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &assignResource{}
+var _ resource.ResourceWithConfigure = &assignResource{}
+var _ resource.ResourceWithImportState = &assignResource{}
+
+func newAssignResource() resource.Resource {
+	return &assignResource{}
+}
+
+type assignResource struct {
+	client opnsense.Client
+}
+
+func (r *assignResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_interfaces_assign"
+}
+
+func (r *assignResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = assignResourceSchema()
+}
+
+func (r *assignResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	apiClient, ok := req.ProviderData.(*api.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *opnsense.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData))
+		return
+	}
+	r.client = opnsense.NewClient(apiClient)
+}
+
+func (r *assignResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *assignResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := convertAssignSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse interfaces assign, got error: %s", err))
+		return
+	}
+	id, err := r.client.Interfaces().AddAssign(ctx, resourceStruct)
+	if err != nil {
+		if id != "" {
+			data.Id = types.StringValue(id)
+			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create interfaces assign, got error: %s", err))
+		return
+	}
+	data.Id = types.StringValue(id)
+	tflog.Trace(ctx, "created a resource")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *assignResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *assignResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := r.client.Interfaces().GetAssign(ctx, data.Id.ValueString())
+	if err != nil {
+		var notFoundError *errs.NotFoundError
+		if errors.As(err, &notFoundError) {
+			tflog.Warn(ctx, "interfaces assign not present in remote, removing from state")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read interfaces assign, got error: %s", err))
+		return
+	}
+	resourceModel, err := convertAssignStructToSchema(resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read interfaces assign, got error: %s", err))
+		return
+	}
+	resourceModel.Id = data.Id
+	resp.Diagnostics.Append(resp.State.Set(ctx, &resourceModel)...)
+}
+
+func (r *assignResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *assignResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resourceStruct, err := convertAssignSchemaToStruct(data)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to parse interfaces assign, got error: %s", err))
+		return
+	}
+	err = r.client.Interfaces().UpdateAssign(ctx, data.Id.ValueString(), resourceStruct)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update interfaces assign, got error: %s", err))
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *assignResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *assignResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	err := r.client.Interfaces().DeleteAssign(ctx, data.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete interfaces assign, got error: %s", err))
+		return
+	}
+}
+
+func (r *assignResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/service/interfaces/assign_resource_test.go
+++ b/internal/service/interfaces/assign_resource_test.go
@@ -1,0 +1,49 @@
+package interfaces_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/browningluke/terraform-provider-opnsense/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccInterfacesAssignResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInterfacesAssignResourceConfig("192.168.1.1", "24", "Test interface assign"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_interfaces_assign.test", "ip", "192.168.1.1"),
+					resource.TestCheckResourceAttr("opnsense_interfaces_assign.test", "subnet", "24"),
+					resource.TestCheckResourceAttr("opnsense_interfaces_assign.test", "description", "Test interface assign"),
+					resource.TestCheckResourceAttrSet("opnsense_interfaces_assign.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "opnsense_interfaces_assign.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccInterfacesAssignResourceConfig("192.168.2.1", "24", "Updated interface assign"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("opnsense_interfaces_assign.test", "ip", "192.168.2.1"),
+					resource.TestCheckResourceAttr("opnsense_interfaces_assign.test", "description", "Updated interface assign"),
+				),
+			},
+		},
+	})
+}
+
+func testAccInterfacesAssignResourceConfig(ip, subnet, description string) string {
+	return fmt.Sprintf(`
+resource "opnsense_interfaces_assign" "test" {
+  ip          = %[1]q
+  subnet      = %[2]q
+  description = %[3]q
+}
+`, ip, subnet, description)
+}

--- a/internal/service/interfaces/assign_schema.go
+++ b/internal/service/interfaces/assign_schema.go
@@ -1,0 +1,146 @@
+package interfaces
+
+import (
+	"github.com/browningluke/opnsense-go/pkg/interfaces"
+	"github.com/browningluke/terraform-provider-opnsense/internal/tools"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type assignResourceModel struct {
+	Interface        types.String `tfsdk:"interface"`
+	Device           types.String `tfsdk:"device"`
+	Ip               types.String `tfsdk:"ip"`
+	Subnet           types.String `tfsdk:"subnet"`
+	Gateway          types.String `tfsdk:"gateway"`
+	GatewayInterface types.String `tfsdk:"gateway_interface"`
+	Enable           types.Bool   `tfsdk:"enable"`
+	Description      types.String `tfsdk:"description"`
+
+	Id types.String `tfsdk:"id"`
+}
+
+func assignResourceSchema() schema.Schema {
+	return schema.Schema{
+		MarkdownDescription: "Manages an OPNsense interface assignment.",
+
+		Attributes: map[string]schema.Attribute{
+			"interface": schema.StringAttribute{
+				MarkdownDescription: "The interface name.",
+				Optional:            true,
+			},
+			"device": schema.StringAttribute{
+				MarkdownDescription: "The device.",
+				Optional:            true,
+			},
+			"ip": schema.StringAttribute{
+				MarkdownDescription: "The IP address.",
+				Optional:            true,
+			},
+			"subnet": schema.StringAttribute{
+				MarkdownDescription: "The subnet.",
+				Optional:            true,
+			},
+			"gateway": schema.StringAttribute{
+				MarkdownDescription: "The gateway.",
+				Optional:            true,
+			},
+			"gateway_interface": schema.StringAttribute{
+				MarkdownDescription: "The gateway interface.",
+				Optional:            true,
+			},
+			"enable": schema.BoolAttribute{
+				MarkdownDescription: "Enable this interface. Defaults to `true`.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(true),
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Description for this assignment.",
+				Optional:            true,
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "UUID of the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func assignDataSourceSchema() dschema.Schema {
+	return dschema.Schema{
+		MarkdownDescription: "Reads an OPNsense interface assignment.",
+
+		Attributes: map[string]dschema.Attribute{
+			"id": dschema.StringAttribute{
+				MarkdownDescription: "UUID of the resource.",
+				Required:            true,
+			},
+			"interface": dschema.StringAttribute{
+				MarkdownDescription: "The interface name.",
+				Computed:            true,
+			},
+			"device": dschema.StringAttribute{
+				MarkdownDescription: "The device.",
+				Computed:            true,
+			},
+			"ip": dschema.StringAttribute{
+				MarkdownDescription: "The IP address.",
+				Computed:            true,
+			},
+			"subnet": dschema.StringAttribute{
+				MarkdownDescription: "The subnet.",
+				Computed:            true,
+			},
+			"gateway": dschema.StringAttribute{
+				MarkdownDescription: "The gateway.",
+				Computed:            true,
+			},
+			"gateway_interface": dschema.StringAttribute{
+				MarkdownDescription: "The gateway interface.",
+				Computed:            true,
+			},
+			"enable": dschema.BoolAttribute{
+				MarkdownDescription: "Whether this interface is enabled.",
+				Computed:            true,
+			},
+			"description": dschema.StringAttribute{
+				MarkdownDescription: "Description for this assignment.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func convertAssignSchemaToStruct(d *assignResourceModel) (*interfaces.Assign, error) {
+	return &interfaces.Assign{
+		Interface:        d.Interface.ValueString(),
+		Device:           d.Device.ValueString(),
+		Ip:               d.Ip.ValueString(),
+		Subnet:           d.Subnet.ValueString(),
+		Gateway:          d.Gateway.ValueString(),
+		GatewayInterface: d.GatewayInterface.ValueString(),
+		Enable:           tools.BoolToString(d.Enable.ValueBool()),
+		Description:      d.Description.ValueString(),
+	}, nil
+}
+
+func convertAssignStructToSchema(d *interfaces.Assign) (*assignResourceModel, error) {
+	return &assignResourceModel{
+		Interface:        tools.StringOrNull(d.Interface),
+		Device:           tools.StringOrNull(d.Device),
+		Ip:               tools.StringOrNull(d.Ip),
+		Subnet:           tools.StringOrNull(d.Subnet),
+		Gateway:          tools.StringOrNull(d.Gateway),
+		GatewayInterface: tools.StringOrNull(d.GatewayInterface),
+		Enable:           types.BoolValue(tools.StringToBool(d.Enable)),
+		Description:      tools.StringOrNull(d.Description),
+	}, nil
+}

--- a/templates/data-sources/auth_group.md.tmpl
+++ b/templates/data-sources/auth_group.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/data-sources/auth_user.md.tmpl
+++ b/templates/data-sources/auth_user.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/data-sources/bind_acl.md.tmpl
+++ b/templates/data-sources/bind_acl.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/data-sources/bind_primary_domain.md.tmpl
+++ b/templates/data-sources/bind_primary_domain.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/data-sources/bind_record.md.tmpl
+++ b/templates/data-sources/bind_record.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/data-sources/dnsmasq_boot.md.tmpl
+++ b/templates/data-sources/dnsmasq_boot.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/data-sources/dnsmasq_domain.md.tmpl
+++ b/templates/data-sources/dnsmasq_domain.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/data-sources/dnsmasq_host.md.tmpl
+++ b/templates/data-sources/dnsmasq_host.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/data-sources/dnsmasq_option.md.tmpl
+++ b/templates/data-sources/dnsmasq_option.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/data-sources/dnsmasq_range.md.tmpl
+++ b/templates/data-sources/dnsmasq_range.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/data-sources/dnsmasq_tag.md.tmpl
+++ b/templates/data-sources/dnsmasq_tag.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/data-sources/interfaces_assign.md.tmpl
+++ b/templates/data-sources/interfaces_assign.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/resources/auth_group.md.tmpl
+++ b/templates/resources/auth_group.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/resources/auth_user.md.tmpl
+++ b/templates/resources/auth_user.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/resources/bind_acl.md.tmpl
+++ b/templates/resources/bind_acl.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/resources/bind_primary_domain.md.tmpl
+++ b/templates/resources/bind_primary_domain.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/resources/bind_record.md.tmpl
+++ b/templates/resources/bind_record.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/resources/dnsmasq_boot.md.tmpl
+++ b/templates/resources/dnsmasq_boot.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/resources/dnsmasq_domain.md.tmpl
+++ b/templates/resources/dnsmasq_domain.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/resources/dnsmasq_host.md.tmpl
+++ b/templates/resources/dnsmasq_host.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/resources/dnsmasq_option.md.tmpl
+++ b/templates/resources/dnsmasq_option.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/resources/dnsmasq_range.md.tmpl
+++ b/templates/resources/dnsmasq_range.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/resources/dnsmasq_tag.md.tmpl
+++ b/templates/resources/dnsmasq_tag.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}

--- a/templates/resources/interfaces_assign.md.tmpl
+++ b/templates/resources/interfaces_assign.md.tmpl
@@ -1,0 +1,1 @@
+{{ .SchemaMarkdown }}


### PR DESCRIPTION
## Summary

Adds 13 new resources and 13 new data sources for OPNsense modules not yet covered by the provider:

### New Resources
| Package | Resources |
|---------|-----------|
| **auth** | `opnsense_auth_user`, `opnsense_auth_group` |
| **bind** | `opnsense_bind_acl`, `opnsense_bind_primary_domain`, `opnsense_bind_record` |
| **dnsmasq** | `opnsense_dnsmasq_boot`, `opnsense_dnsmasq_domain`, `opnsense_dnsmasq_host`, `opnsense_dnsmasq_option`, `opnsense_dnsmasq_range`, `opnsense_dnsmasq_tag` |
| **interfaces** | `opnsense_interfaces_assign` |

### Each resource includes
- Full CRUD with import support
- Read-only data source
- Acceptance tests (create → verify → import → update → verify → delete)
- Doc templates

### Changes
- Bumps `opnsense-go` from v0.14.0 to v0.15.0 (adds auth + dnsmasq packages)
- New service sub-packages follow existing architecture (`internal/service/<pkg>/`)
- Tests use the `internal/acctest` framework matching upstream patterns
- 79 files changed, ~5,400 lines added

### Note
This replaces the earlier PR #5 which had merge conflicts due to the recent refactor. That PR can be closed.